### PR TITLE
Implement Error Handling to Transformer Registry

### DIFF
--- a/sample/src/main/java/com/trendyol/transmission/features/output/OutputTransformer.kt
+++ b/sample/src/main/java/com/trendyol/transmission/features/output/OutputTransformer.kt
@@ -1,5 +1,6 @@
 package com.trendyol.transmission.features.output
 
+import android.util.Log
 import com.trendyol.transmission.DefaultDispatcher
 import com.trendyol.transmission.effect.RouterEffect
 import com.trendyol.transmission.features.colorpicker.ColorPickerEffect
@@ -46,6 +47,10 @@ class OutputTransformer @Inject constructor(
             .registerExecution(outputExecutionContract) {
                 delay(4.seconds)
                 communicationScope.publish(ColorPickerEffect.BackgroundColorUpdate(Pink80))
+                throw RuntimeException(
+                    "This exception will be properly handled and caught " +
+                            "inside of the onError() function"
+                )
             }
     }
 
@@ -71,7 +76,13 @@ class OutputTransformer @Inject constructor(
         }
     }
 
+    override fun onError(throwable: Throwable) {
+        super.onError(throwable)
+        Log.e(TAG, "onError: ${throwable.localizedMessage}")
+    }
+
     companion object {
+        private const val TAG = "OutputTransformer"
         val outputCalculationContract =
             buildComputationContract<OutputCalculationResult>("OutputCalculationResult")
         val outputExecutionContract =

--- a/transmission/src/main/java/com/trendyol/transmission/router/RequestDelegate.kt
+++ b/transmission/src/main/java/com/trendyol/transmission/router/RequestDelegate.kt
@@ -71,12 +71,14 @@ internal class RequestDelegate(
         query: Query.Computation
     ) = queryScope.launch {
         val computationHolder = routerRef.transformerSet
-            .find { it.storage.hasComputation(query.key) } ?: return@launch
+            .find { it.storage.hasComputation(query.key) }
         val computationToSend = queryScope.async {
             val computationData = runCatching {
-                computationHolder.storage.getComputationByKey(query.key)
+                computationHolder?.storage?.getComputationByKey(query.key)
                     ?.getResult(computationHolder.communicationScope, query.invalidate)
-            }.onFailure(computationHolder::onError).getOrNull()
+            }.onFailure{
+                computationHolder?.onError(it)
+            }.getOrNull()
 
             QueryResult.Computation(
                 owner = query.sender,
@@ -99,16 +101,18 @@ internal class RequestDelegate(
         query: Query.ComputationWithArgs<A>
     ) = queryScope.launch {
         val computationHolder = routerRef.transformerSet
-            .find { it.storage.hasComputation(query.key) } ?: return@launch
+            .find { it.storage.hasComputation(query.key) }
         val computationToSend = queryScope.async {
             val computationData = runCatching {
-                computationHolder.storage.getComputationByKey<A>(query.key)
+                computationHolder?.storage?.getComputationByKey<A>(query.key)
                     ?.getResult(
                         computationHolder.communicationScope,
                         query.invalidate,
                         query.args
                     )
-            }.onFailure(computationHolder::onError).getOrNull()
+            }.onFailure{
+                computationHolder?.onError(it)
+            }.getOrNull()
 
             QueryResult.Computation(
                 owner = query.sender,

--- a/transmission/src/main/java/com/trendyol/transmission/router/RequestDelegate.kt
+++ b/transmission/src/main/java/com/trendyol/transmission/router/RequestDelegate.kt
@@ -71,13 +71,17 @@ internal class RequestDelegate(
         query: Query.Computation
     ) = queryScope.launch {
         val computationHolder = routerRef.transformerSet
-            .find { it.storage.hasComputation(query.key) }
+            .find { it.storage.hasComputation(query.key) } ?: return@launch
         val computationToSend = queryScope.async {
+            val computationData = runCatching {
+                computationHolder.storage.getComputationByKey(query.key)
+                    ?.getResult(computationHolder.communicationScope, query.invalidate)
+            }.onFailure(computationHolder::onError).getOrNull()
+
             QueryResult.Computation(
                 owner = query.sender,
                 key = query.key,
-                data = computationHolder?.storage?.getComputationByKey(query.key)
-                    ?.getResult(computationHolder.communicationScope, query.invalidate),
+                data = computationData,
             )
         }
         if (query.sender == routerRef.routerName) {
@@ -95,13 +99,21 @@ internal class RequestDelegate(
         query: Query.ComputationWithArgs<A>
     ) = queryScope.launch {
         val computationHolder = routerRef.transformerSet
-            .find { it.storage.hasComputation(query.key) }
+            .find { it.storage.hasComputation(query.key) } ?: return@launch
         val computationToSend = queryScope.async {
+            val computationData = runCatching {
+                computationHolder.storage.getComputationByKey<A>(query.key)
+                    ?.getResult(
+                        computationHolder.communicationScope,
+                        query.invalidate,
+                        query.args
+                    )
+            }.onFailure(computationHolder::onError).getOrNull()
+
             QueryResult.Computation(
                 owner = query.sender,
                 key = query.key,
-                data = computationHolder?.storage?.getComputationByKey<A>(query.key)
-                    ?.getResult(computationHolder.communicationScope, query.invalidate, query.args),
+                data = computationData,
             )
         }
         if (query.sender == routerRef.routerName) {
@@ -119,17 +131,21 @@ internal class RequestDelegate(
         query: Query.Execution
     ) = queryScope.launch {
         val executionHolder = routerRef.transformerSet
-            .find { it.storage.hasExecution(query.key) }
-        executionHolder?.storage?.getExecutionByKey(query.key)
-            ?.execute(executionHolder.communicationScope)
+            .find { it.storage.hasExecution(query.key) } ?: return@launch
+        runCatching {
+            executionHolder.storage.getExecutionByKey(query.key)
+                ?.execute(executionHolder.communicationScope)
+        }.onFailure(executionHolder::onError).getOrNull()
     }
 
     private fun <A : Any> processExecutionWithArgs(query: Query.ExecutionWithArgs<A>) =
         queryScope.launch {
             val executionHolder = routerRef.transformerSet
-                .find { it.storage.hasExecution(query.key) }
-            executionHolder?.storage?.getExecutionByKey<A>(query.key)
-                ?.execute(executionHolder.communicationScope, query.args)
+                .find { it.storage.hasExecution(query.key) } ?: return@launch
+            runCatching {
+                executionHolder.storage.getExecutionByKey<A>(query.key)
+                    ?.execute(executionHolder.communicationScope, query.args)
+            }.onFailure(executionHolder::onError).getOrNull()
         }
 
     override suspend fun <C : Contract.Data<D>, D : Transmission.Data> getData(contract: C): D? {

--- a/transmission/src/main/java/com/trendyol/transmission/transformer/Transformer.kt
+++ b/transmission/src/main/java/com/trendyol/transmission/transformer/Transformer.kt
@@ -13,6 +13,7 @@ import com.trendyol.transmission.transformer.request.computation.ComputationRegi
 import com.trendyol.transmission.transformer.request.createIdentity
 import com.trendyol.transmission.transformer.request.execution.ExecutionRegistry
 import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -33,7 +34,10 @@ open class Transformer(
     identity: Contract.Identity? = null
 ) {
 
-    val transformerScope = CoroutineScope(dispatcher + SupervisorJob())
+    private val exceptionHandler = CoroutineExceptionHandler { _, throwable ->
+        onError(throwable)
+    }
+    val transformerScope = CoroutineScope(dispatcher + SupervisorJob() + exceptionHandler)
 
     private val internalIdentity: Contract.Identity =
         identity ?: createIdentity(this::class.simpleName.orEmpty())
@@ -122,5 +126,9 @@ open class Transformer(
     fun clear() {
         transformerScope.cancel()
         storage.clear()
+    }
+
+    open fun onError(throwable: Throwable) {
+        // no-operation
     }
 }

--- a/transmission/src/main/java/com/trendyol/transmission/transformer/request/computation/ComputationExt.kt
+++ b/transmission/src/main/java/com/trendyol/transmission/transformer/request/computation/ComputationExt.kt
@@ -11,7 +11,6 @@ import com.trendyol.transmission.transformer.request.RequestHandler
  *
  * Adds a computation to [Transformer] to be queried.
  * Can be queried using [RequestHandler.execute]
- * @param useCache Stores the result after first computation
  * @param computation Computation to get the result [Transmission.Data]
  */
 fun <C : Contract.Computation<T>, T : Any> ComputationRegistry.registerComputation(
@@ -27,7 +26,6 @@ fun <C : Contract.Computation<T>, T : Any> ComputationRegistry.registerComputati
  *
  * Adds a computation to [Transformer] to be queried. This computation accepts any class as Argument.
  * Can be queried using [RequestHandler.execute]
- * @param useCache Stores the result after first computation
  * @param computation Computation to get the result [Transmission.Data]
  */
 fun <C : Contract.ComputationWithArgs<A, T>, A : Any, T : Any> ComputationRegistry.registerComputation(


### PR DESCRIPTION
I have added the onError() open function to `Transformer`. Any exception on `transformerScope` child jobs or `registerComputation` and `registerExecution` will be caught and reported via the onError() function.