### PR TITLE
Make handler Registry constructor internal

### DIFF
--- a/transmission/src/main/java/com/trendyol/transmission/transformer/Transformer.kt
+++ b/transmission/src/main/java/com/trendyol/transmission/transformer/Transformer.kt
@@ -4,9 +4,7 @@ import com.trendyol.transmission.Transmission
 import com.trendyol.transmission.effect.EffectWrapper
 import com.trendyol.transmission.effect.RouterEffect
 import com.trendyol.transmission.transformer.handler.CommunicationScope
-import com.trendyol.transmission.transformer.handler.EffectHandler
 import com.trendyol.transmission.transformer.handler.HandlerRegistry
-import com.trendyol.transmission.transformer.handler.SignalHandler
 import com.trendyol.transmission.transformer.request.Contract
 import com.trendyol.transmission.transformer.request.Query
 import com.trendyol.transmission.transformer.request.QueryResult

--- a/transmission/src/main/java/com/trendyol/transmission/transformer/handler/HandlerRegistry.kt
+++ b/transmission/src/main/java/com/trendyol/transmission/transformer/handler/HandlerRegistry.kt
@@ -6,7 +6,7 @@ import com.trendyol.transmission.Transmission
 import com.trendyol.transmission.transformer.Transformer
 import kotlin.reflect.KClass
 
-class HandlerScope(val handlerRegistry: HandlerRegistry)
+class HandlerScope internal constructor(val handlerRegistry: HandlerRegistry)
 
 fun Transformer.handlerRegistry(scope: HandlerScope.() -> Unit): HandlerRegistry {
     val handlerRegistry = HandlerRegistry()


### PR DESCRIPTION
This MR updates the constructor visibility of `HandlerRegistry`. 

With this update, only way to create the registry will be `handlerRegistry` function with `Transformer` as its receiver type.