### PR TITLE
Transformer set Loader

### DIFF
--- a/sample/src/main/java/com/trendyol/transmission/SampleViewModel.kt
+++ b/sample/src/main/java/com/trendyol/transmission/SampleViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.viewModelScope
 import com.trendyol.transmission.effect.RouterEffect
 import com.trendyol.transmission.features.colorpicker.ColorPickerTransformer
 import com.trendyol.transmission.features.input.InputTransformer
+import com.trendyol.transmission.router.TransmissionRouter
 import com.trendyol.transmission.router.onEach
 import com.trendyol.transmission.router.toState
 import com.trendyol.transmission.ui.ColorPickerUiState

--- a/sample/src/main/java/com/trendyol/transmission/features/FeaturesModule.kt
+++ b/sample/src/main/java/com/trendyol/transmission/features/FeaturesModule.kt
@@ -1,6 +1,6 @@
 package com.trendyol.transmission.features
 
-import com.trendyol.transmission.TransmissionRouter
+import com.trendyol.transmission.router.TransmissionRouter
 import com.trendyol.transmission.features.colorpicker.ColorPickerTransformer
 import com.trendyol.transmission.features.input.InputTransformer
 import com.trendyol.transmission.features.multioutput.MultiOutputTransformer

--- a/transmission-test/src/main/java/com/trendyol/transmissiontest/TestSuite.kt
+++ b/transmission-test/src/main/java/com/trendyol/transmissiontest/TestSuite.kt
@@ -1,7 +1,7 @@
 package com.trendyol.transmissiontest
 
 import com.trendyol.transmission.Transmission
-import com.trendyol.transmission.TransmissionRouter
+import com.trendyol.transmission.router.TransmissionRouter
 import com.trendyol.transmission.router.RegistryScope
 import com.trendyol.transmission.router.builder.TransmissionTestingRouterBuilder
 import com.trendyol.transmission.transformer.Transformer

--- a/transmission/src/main/java/com/trendyol/transmission/effect/RouterEffect.kt
+++ b/transmission/src/main/java/com/trendyol/transmission/effect/RouterEffect.kt
@@ -1,7 +1,7 @@
 package com.trendyol.transmission.effect
 
 import com.trendyol.transmission.Transmission
-import com.trendyol.transmission.TransmissionRouter
+import com.trendyol.transmission.router.TransmissionRouter
 import com.trendyol.transmission.transformer.Transformer
 
 /**

--- a/transmission/src/main/java/com/trendyol/transmission/router/RequestDelegate.kt
+++ b/transmission/src/main/java/com/trendyol/transmission/router/RequestDelegate.kt
@@ -1,7 +1,6 @@
 package com.trendyol.transmission.router
 
 import com.trendyol.transmission.Transmission
-import com.trendyol.transmission.TransmissionRouter
 import com.trendyol.transmission.transformer.request.Contract
 import com.trendyol.transmission.transformer.request.Query
 import com.trendyol.transmission.transformer.request.QueryResult

--- a/transmission/src/main/java/com/trendyol/transmission/router/TransmissionRouter.kt
+++ b/transmission/src/main/java/com/trendyol/transmission/router/TransmissionRouter.kt
@@ -1,9 +1,7 @@
-package com.trendyol.transmission
+package com.trendyol.transmission.router
 
+import com.trendyol.transmission.Transmission
 import com.trendyol.transmission.effect.EffectWrapper
-import com.trendyol.transmission.router.RegistryScopeImpl
-import com.trendyol.transmission.router.RequestDelegate
-import com.trendyol.transmission.router.createBroadcast
 import com.trendyol.transmission.transformer.Transformer
 import com.trendyol.transmission.transformer.request.RequestHandler
 import kotlinx.coroutines.CoroutineDispatcher

--- a/transmission/src/main/java/com/trendyol/transmission/router/builder/TransmissionRouterBuilder.kt
+++ b/transmission/src/main/java/com/trendyol/transmission/router/builder/TransmissionRouterBuilder.kt
@@ -1,13 +1,13 @@
 package com.trendyol.transmission.router.builder
 
-import com.trendyol.transmission.TransmissionRouter
+import com.trendyol.transmission.router.TransmissionRouter
 
 object TransmissionRouterBuilder {
 
     fun build(scope: TransmissionRouterBuilderScope.() -> Unit): TransmissionRouter {
         val builder = TransmissionRouterBuilderInternal(scope)
         return TransmissionRouter(
-            transformerSet = builder.transformerSet,
+            transformerSetLoader = builder.transformerSetLoader,
             dispatcher = builder.dispatcher,
         )
     }

--- a/transmission/src/main/java/com/trendyol/transmission/router/builder/TransmissionRouterBuilderInternal.kt
+++ b/transmission/src/main/java/com/trendyol/transmission/router/builder/TransmissionRouterBuilderInternal.kt
@@ -2,6 +2,7 @@ package com.trendyol.transmission.router.builder
 
 import com.trendyol.transmission.router.RegistryScope
 import com.trendyol.transmission.router.RegistryScopeImpl
+import com.trendyol.transmission.router.loader.TransformerSetLoader
 import com.trendyol.transmission.transformer.Transformer
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
@@ -11,8 +12,8 @@ internal class TransmissionRouterBuilderInternal internal constructor(
 ) {
 
     internal var dispatcher: CoroutineDispatcher = Dispatchers.Default
-    internal var transformerSet = setOf<Transformer>()
     internal var registryScope: RegistryScopeImpl? = null
+    internal lateinit var transformerSetLoader: TransformerSetLoader
 
     private val scopeImpl = object : TransmissionTestingRouterBuilderScope {
 
@@ -26,8 +27,18 @@ internal class TransmissionRouterBuilderInternal internal constructor(
         }
 
         override fun withTransformerSet(transformerSet: Set<Transformer>) {
-            this@TransmissionRouterBuilderInternal.transformerSet = transformerSet
+            val loader = object: TransformerSetLoader {
+                override suspend fun load(): Set<Transformer> {
+                    return transformerSet
+                }
+            }
+            withLoader(loader)
         }
+
+        override fun withLoader(loader: TransformerSetLoader) {
+            this@TransmissionRouterBuilderInternal.transformerSetLoader = loader
+        }
+
     }
 
     init {

--- a/transmission/src/main/java/com/trendyol/transmission/router/builder/TransmissionRouterBuilderInternal.kt
+++ b/transmission/src/main/java/com/trendyol/transmission/router/builder/TransmissionRouterBuilderInternal.kt
@@ -38,7 +38,6 @@ internal class TransmissionRouterBuilderInternal internal constructor(
         override fun withLoader(loader: TransformerSetLoader) {
             this@TransmissionRouterBuilderInternal.transformerSetLoader = loader
         }
-
     }
 
     init {

--- a/transmission/src/main/java/com/trendyol/transmission/router/builder/TransmissionRouterBuilderScope.kt
+++ b/transmission/src/main/java/com/trendyol/transmission/router/builder/TransmissionRouterBuilderScope.kt
@@ -1,9 +1,29 @@
 package com.trendyol.transmission.router.builder
 
+import com.trendyol.transmission.router.loader.TransformerSetLoader
+import com.trendyol.transmission.router.TransmissionRouter
 import com.trendyol.transmission.transformer.Transformer
 import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers.Default
 
 interface TransmissionRouterBuilderScope {
+    /**
+     * Sets the [CoroutineDispatcher] to the [TransmissionRouter].
+     * If not provided, [Default] Dispatcher is going to be used.
+     */
     fun withDispatcher(dispatcher: CoroutineDispatcher)
+
+    /**
+     * Sets the [Transformer] set to the [TransmissionRouter].
+     * Either this method or [withLoader] must be used to provide a valid
+     * set of [Transformer]s.
+     */
     fun withTransformerSet(transformerSet: Set<Transformer>)
+
+    /**
+     * Sets [TransformerSetLoader] to the [TransmissionRouter].
+     * Either this method or [withTransformerSet] must be used to provide a valid
+     * set of [Transformer]s.
+     */
+    fun withLoader(loader: TransformerSetLoader)
 }

--- a/transmission/src/main/java/com/trendyol/transmission/router/builder/TransmissionTestingRouterBuilder.kt
+++ b/transmission/src/main/java/com/trendyol/transmission/router/builder/TransmissionTestingRouterBuilder.kt
@@ -1,13 +1,13 @@
 package com.trendyol.transmission.router.builder
 
-import com.trendyol.transmission.TransmissionRouter
+import com.trendyol.transmission.router.TransmissionRouter
 
 object TransmissionTestingRouterBuilder {
 
     fun build(scope: TransmissionTestingRouterBuilderScope.() -> Unit): TransmissionRouter {
         val builder = TransmissionRouterBuilderInternal(scope)
         return TransmissionRouter(
-            transformerSet = builder.transformerSet,
+            transformerSetLoader = builder.transformerSetLoader,
             dispatcher = builder.dispatcher,
             registryScope = builder.registryScope
         )

--- a/transmission/src/main/java/com/trendyol/transmission/router/loader/TransformerSetLoader.kt
+++ b/transmission/src/main/java/com/trendyol/transmission/router/loader/TransformerSetLoader.kt
@@ -1,0 +1,11 @@
+package com.trendyol.transmission.router.loader
+
+import com.trendyol.transmission.transformer.Transformer
+import com.trendyol.transmission.router.TransmissionRouter
+
+interface TransformerSetLoader {
+    /**
+     * This method loads the transformer set to the [TransmissionRouter]
+     */
+    suspend fun load(): Set<Transformer>
+}

--- a/transmission/src/main/java/com/trendyol/transmission/transformer/Transformer.kt
+++ b/transmission/src/main/java/com/trendyol/transmission/transformer/Transformer.kt
@@ -37,7 +37,9 @@ open class Transformer(
     private val exceptionHandler = CoroutineExceptionHandler { _, throwable ->
         onError(throwable)
     }
-    val transformerScope = CoroutineScope(dispatcher + SupervisorJob() + exceptionHandler)
+
+    @PublishedApi
+    internal val transformerScope = CoroutineScope(dispatcher + SupervisorJob() + exceptionHandler)
 
     private val internalIdentity: Contract.Identity =
         identity ?: createIdentity(this::class.simpleName.orEmpty())

--- a/transmission/src/main/java/com/trendyol/transmission/transformer/dataholder/DataHolderExt.kt
+++ b/transmission/src/main/java/com/trendyol/transmission/transformer/dataholder/DataHolderExt.kt
@@ -1,7 +1,7 @@
 package com.trendyol.transmission.transformer.dataholder
 
 import com.trendyol.transmission.Transmission
-import com.trendyol.transmission.TransmissionRouter
+import com.trendyol.transmission.router.TransmissionRouter
 import com.trendyol.transmission.transformer.Transformer
 import com.trendyol.transmission.transformer.request.Contract
 import com.trendyol.transmission.transformer.request.RequestHandler

--- a/transmission/src/main/java/com/trendyol/transmission/transformer/handler/CommunicationScope.kt
+++ b/transmission/src/main/java/com/trendyol/transmission/transformer/handler/CommunicationScope.kt
@@ -1,7 +1,7 @@
 package com.trendyol.transmission.transformer.handler
 
 import com.trendyol.transmission.Transmission
-import com.trendyol.transmission.TransmissionRouter
+import com.trendyol.transmission.router.TransmissionRouter
 import com.trendyol.transmission.transformer.Transformer
 import com.trendyol.transmission.transformer.request.Contract
 import com.trendyol.transmission.transformer.request.RequestHandler

--- a/transmission/src/test/kotlin/com/trendyol/transmission/TransmissionRouterTest.kt
+++ b/transmission/src/test/kotlin/com/trendyol/transmission/TransmissionRouterTest.kt
@@ -3,6 +3,7 @@ package com.trendyol.transmission
 import app.cash.turbine.test
 import app.cash.turbine.turbineScope
 import com.trendyol.transmission.effect.RouterEffect
+import com.trendyol.transmission.router.TransmissionRouter
 import com.trendyol.transmission.transformer.FakeTransformer
 import com.trendyol.transmission.transformer.TestTransformer1
 import com.trendyol.transmission.transformer.TestTransformer2
@@ -16,144 +17,151 @@ import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 import org.junit.Rule
 import org.junit.jupiter.api.Test
-import java.lang.IllegalStateException
 import kotlin.test.assertEquals
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class TransmissionRouterTest {
 
-	private lateinit var sut: TransmissionRouter
+    private lateinit var sut: TransmissionRouter
 
-	@get:Rule
-	val testCoroutineRule = TestCoroutineRule()
+    @get:Rule
+    val testCoroutineRule = TestCoroutineRule()
 
-	private val testDispatcher = UnconfinedTestDispatcher()
+    private val testDispatcher = UnconfinedTestDispatcher()
 
-	@Test
-	fun `GIVEN Router with no transformers, WHEN initialize is called, THEN router should throw IllegalStateException`() =
-		runTest {
-			// Given
-			try {
-				// When
-				sut = TransmissionRouter(setOf())
-			} catch (e: IllegalArgumentException) {
-				// Then
-				assertEquals(e.message, "transformerSet should not be empty")
-			}
-		}
+    @Test
+    fun `GIVEN Router with no transformers, WHEN initialize is called, THEN router should throw IllegalStateException`() =
+        runTest {
+            // Given
+            try {
+                // When
+                sut = TransmissionRouter(setOf())
+            } catch (e: IllegalArgumentException) {
+                // Then
+                assertEquals(e.message, "transformerSet should not be empty")
+            }
+        }
 
-	@Test
-	fun `GIVEN Router with one transformer, WHEN initialize is called, THEN router should not throw IllegalStateException`() =
-		runTest {
-			// Given
-			val exception = try {
-				// When
-				sut = TransmissionRouter(setOf(FakeTransformer(testDispatcher)))
-				null
-			} catch (e: IllegalStateException) {
-				e
-			}
-			// Then
-			assertEquals(exception, null)
-		}
+    @Test
+    fun `GIVEN Router with one transformer, WHEN initialize is called, THEN router should not throw IllegalStateException`() =
+        runTest {
+            // Given
+            val exception = try {
+                // When
+                sut = TransmissionRouter(setOf(FakeTransformer(testDispatcher)))
+                null
+            } catch (e: IllegalStateException) {
+                e
+            }
+            // Then
+            assertEquals(exception, null)
+        }
 
-	@Test
-	fun `GIVEN initialized Router with one Transformer, WHEN processSignal is called, THEN transformer should contain the signal`() {
-		// Given
-		val transformer = FakeTransformer(testDispatcher)
-		sut = TransmissionRouter(setOf(transformer), testDispatcher)
-		// When
-		sut.processSignal(TestSignal)
+    @Test
+    fun `GIVEN initialized Router with one Transformer, WHEN processSignal is called, THEN transformer should contain the signal`() {
+        // Given
+        val transformer = FakeTransformer(testDispatcher)
+        sut = TransmissionRouter(setOf(transformer), testDispatcher)
+        // When
+        sut.processSignal(TestSignal)
 
-		// Then
-		assertEquals(transformer.signalList.last(), TestSignal)
-	}
+        // Then
+        assertEquals(transformer.signalList.last(), TestSignal)
+    }
 
-	@Test
-	fun `GIVEN initialized Router with multiple Transformers, WHEN processSignal is called, THEN all transformers should contain the signal`() {
-		// Given
-		val transformer1 = TestTransformer1(testDispatcher)
-		val transformer2 = TestTransformer2(testDispatcher)
-		val transformer3 = TestTransformer3(testDispatcher)
-		sut = TransmissionRouter(setOf(transformer1, transformer2, transformer3), testDispatcher)
-		// When
-		sut.processSignal(TestSignal)
+    @Test
+    fun `GIVEN initialized Router with multiple Transformers, WHEN processSignal is called, THEN all transformers should contain the signal`() {
+        // Given
+        val transformer1 = TestTransformer1(testDispatcher)
+        val transformer2 = TestTransformer2(testDispatcher)
+        val transformer3 = TestTransformer3(testDispatcher)
+        sut = TransmissionRouter(setOf(transformer1, transformer2, transformer3), testDispatcher)
+        // When
+        sut.processSignal(TestSignal)
 
-		// Then
-		assertEquals(transformer1.signalList.last(), TestSignal)
-		assertEquals(transformer2.signalList.last(), TestSignal)
-		assertEquals(transformer3.signalList.last(), TestSignal)
-	}
+        // Then
+        assertEquals(transformer1.signalList.last(), TestSignal)
+        assertEquals(transformer2.signalList.last(), TestSignal)
+        assertEquals(transformer3.signalList.last(), TestSignal)
+    }
 
-	/**
-	 * This test depends on the specific implementation of [FakeTransformer]. Added this to check
-	 * the effect broadcast.
-	 */
-	@Test
-	fun `GIVEN initialized Router with multiple Transformers, WHEN processSignal is called, THEN all transformers should contain the FakeTransformer's Signal`() {
-		// Given
-		val transformer1 = TestTransformer1(testDispatcher)
-		val transformer2 = TestTransformer2(testDispatcher)
-		val transformer3 = TestTransformer3(testDispatcher)
-		sut = TransmissionRouter(setOf(transformer1, transformer2, transformer3), testDispatcher)
-		// When
-		sut.processSignal(TestSignal)
+    /**
+     * This test depends on the specific implementation of [FakeTransformer]. Added this to check
+     * the effect broadcast.
+     */
+    @Test
+    fun `GIVEN initialized Router with multiple Transformers, WHEN processSignal is called, THEN all transformers should contain the FakeTransformer's Signal`() {
+        // Given
+        val transformer1 = TestTransformer1(testDispatcher)
+        val transformer2 = TestTransformer2(testDispatcher)
+        val transformer3 = TestTransformer3(testDispatcher)
+        sut = TransmissionRouter(setOf(transformer1, transformer2, transformer3), testDispatcher)
+        // When
+        sut.processSignal(TestSignal)
 
-		// Then
-		assertEquals(transformer1.effectList.last(), TestEffect)
-		assertEquals(transformer2.effectList.last(), TestEffect)
-		assertEquals(transformer3.effectList.last(), TestEffect)
-	}
+        // Then
+        assertEquals(transformer1.effectList.last(), TestEffect)
+        assertEquals(transformer2.effectList.last(), TestEffect)
+        assertEquals(transformer3.effectList.last(), TestEffect)
+    }
 
-	@Test
-	fun `GIVEN initialized Router with multiple Transformers, WHEN processSignal is called, THEN all effects should be sent through onEffect`() = runTest {
-		turbineScope {
-			// Given
-			val transformer1 = TestTransformer1(testDispatcher)
-			val transformer2 = TestTransformer2(testDispatcher)
-			val transformer3 = TestTransformer3(testDispatcher)
-			sut = TransmissionRouter(setOf(transformer1, transformer2, transformer3), testDispatcher)
-			// When
-			val effects  = sut.effectStream.testIn(backgroundScope)
-			sut.processSignal(TestSignal)
-			assertEquals(6, effects.cancelAndConsumeRemainingEvents().size)
-			// Then
-		}
-	}
+    @Test
+    fun `GIVEN initialized Router with multiple Transformers, WHEN processSignal is called, THEN all effects should be sent through onEffect`() =
+        runTest {
+            turbineScope {
+                // Given
+                val transformer1 = TestTransformer1(testDispatcher)
+                val transformer2 = TestTransformer2(testDispatcher)
+                val transformer3 = TestTransformer3(testDispatcher)
+                sut = TransmissionRouter(
+                    setOf(transformer1, transformer2, transformer3),
+                    testDispatcher
+                )
+                // When
+                val effects = sut.effectStream.testIn(backgroundScope)
+                sut.processSignal(TestSignal)
+                assertEquals(6, effects.cancelAndConsumeRemainingEvents().size)
+                // Then
+            }
+        }
 
-	@Test
-	fun `GIVEN initialized Router with multiple Transformers, WHEN processSignal is called, THEN all transformers should send the correct TestData`() = runTest {
-		turbineScope {
-			// Given
-			val transformer1 = TestTransformer1(testDispatcher)
-			val transformer2 = TestTransformer2(testDispatcher)
-			val transformer3 = TestTransformer3(testDispatcher)
-			sut = TransmissionRouter(setOf(transformer1, transformer2, transformer3), testDispatcher)
-			// When
-			sut.processSignal(TestSignal)
-			sut.dataStream.test {
-				assertEquals(TestData("update with TestTransformer1"), awaitItem())
-				assertEquals(TestData("update with TestTransformer2"), awaitItem())
-				assertEquals(TestData("update with TestTransformer3"), awaitItem())
-			}
+    @Test
+    fun `GIVEN initialized Router with multiple Transformers, WHEN processSignal is called, THEN all transformers should send the correct TestData`() =
+        runTest {
+            turbineScope {
+                // Given
+                val transformer1 = TestTransformer1(testDispatcher)
+                val transformer2 = TestTransformer2(testDispatcher)
+                val transformer3 = TestTransformer3(testDispatcher)
+                sut = TransmissionRouter(
+                    setOf(transformer1, transformer2, transformer3),
+                    testDispatcher
+                )
+                // When
+                sut.processSignal(TestSignal)
+                sut.dataStream.test {
+                    assertEquals(TestData("update with TestTransformer1"), awaitItem())
+                    assertEquals(TestData("update with TestTransformer2"), awaitItem())
+                    assertEquals(TestData("update with TestTransformer3"), awaitItem())
+                }
 
-			// Then
-		}
-	}
+                // Then
+            }
+        }
 
-	@Test
-	fun `GIVEN initialized Router with multiple Transformers, WHEN processSignal is called, THEN all transformers should not contain the RouterPayloadEffect`() {
-		// Given
-		val transformer1 = TestTransformer1(testDispatcher)
-		val transformer2 = TestTransformer2(testDispatcher)
-		val transformer3 = TestTransformer3(testDispatcher)
-		sut = TransmissionRouter(setOf(transformer1, transformer2, transformer3), testDispatcher)
-		// When
-		sut.processSignal(TestSignal)
+    @Test
+    fun `GIVEN initialized Router with multiple Transformers, WHEN processSignal is called, THEN all transformers should not contain the RouterPayloadEffect`() {
+        // Given
+        val transformer1 = TestTransformer1(testDispatcher)
+        val transformer2 = TestTransformer2(testDispatcher)
+        val transformer3 = TestTransformer3(testDispatcher)
+        sut = TransmissionRouter(setOf(transformer1, transformer2, transformer3), testDispatcher)
+        // When
+        sut.processSignal(TestSignal)
 
-		// Then
-		assertEquals(transformer1.effectList.contains(RouterEffect("")),false )
-		assertEquals(transformer2.effectList.contains(RouterEffect("")),false )
-		assertEquals(transformer3.effectList.contains(RouterEffect("")),false )
-	}
+        // Then
+        assertEquals(transformer1.effectList.contains(RouterEffect("")), false)
+        assertEquals(transformer2.effectList.contains(RouterEffect("")), false)
+        assertEquals(transformer3.effectList.contains(RouterEffect("")), false)
+    }
 }

--- a/transmission/src/test/kotlin/com/trendyol/transmission/TransmissionRouterTest.kt
+++ b/transmission/src/test/kotlin/com/trendyol/transmission/TransmissionRouterTest.kt
@@ -4,6 +4,7 @@ import app.cash.turbine.test
 import app.cash.turbine.turbineScope
 import com.trendyol.transmission.effect.RouterEffect
 import com.trendyol.transmission.router.TransmissionRouter
+import com.trendyol.transmission.router.builder.TransmissionRouterBuilder
 import com.trendyol.transmission.transformer.FakeTransformer
 import com.trendyol.transmission.transformer.TestTransformer1
 import com.trendyol.transmission.transformer.TestTransformer2
@@ -35,7 +36,10 @@ class TransmissionRouterTest {
             // Given
             try {
                 // When
-                sut = TransmissionRouter(setOf())
+                sut = TransmissionRouterBuilder.build {
+                    withTransformerSet(setOf())
+                    withDispatcher(testDispatcher)
+                }
             } catch (e: IllegalArgumentException) {
                 // Then
                 assertEquals(e.message, "transformerSet should not be empty")
@@ -48,7 +52,10 @@ class TransmissionRouterTest {
             // Given
             val exception = try {
                 // When
-                sut = TransmissionRouter(setOf(FakeTransformer(testDispatcher)))
+                sut = TransmissionRouterBuilder.build {
+                    withTransformerSet(setOf(FakeTransformer(testDispatcher)))
+                    withDispatcher(testDispatcher)
+                }
                 null
             } catch (e: IllegalStateException) {
                 e
@@ -61,7 +68,10 @@ class TransmissionRouterTest {
     fun `GIVEN initialized Router with one Transformer, WHEN processSignal is called, THEN transformer should contain the signal`() {
         // Given
         val transformer = FakeTransformer(testDispatcher)
-        sut = TransmissionRouter(setOf(transformer), testDispatcher)
+        sut = TransmissionRouterBuilder.build {
+            withTransformerSet(setOf(transformer))
+            withDispatcher(testDispatcher)
+        }
         // When
         sut.processSignal(TestSignal)
 
@@ -75,7 +85,10 @@ class TransmissionRouterTest {
         val transformer1 = TestTransformer1(testDispatcher)
         val transformer2 = TestTransformer2(testDispatcher)
         val transformer3 = TestTransformer3(testDispatcher)
-        sut = TransmissionRouter(setOf(transformer1, transformer2, transformer3), testDispatcher)
+        sut = TransmissionRouterBuilder.build {
+            withTransformerSet(setOf(transformer1, transformer2, transformer3))
+            withDispatcher(testDispatcher)
+        }
         // When
         sut.processSignal(TestSignal)
 
@@ -95,7 +108,10 @@ class TransmissionRouterTest {
         val transformer1 = TestTransformer1(testDispatcher)
         val transformer2 = TestTransformer2(testDispatcher)
         val transformer3 = TestTransformer3(testDispatcher)
-        sut = TransmissionRouter(setOf(transformer1, transformer2, transformer3), testDispatcher)
+        sut = TransmissionRouterBuilder.build {
+            withTransformerSet(setOf(transformer1, transformer2, transformer3))
+            withDispatcher(testDispatcher)
+        }
         // When
         sut.processSignal(TestSignal)
 
@@ -113,10 +129,10 @@ class TransmissionRouterTest {
                 val transformer1 = TestTransformer1(testDispatcher)
                 val transformer2 = TestTransformer2(testDispatcher)
                 val transformer3 = TestTransformer3(testDispatcher)
-                sut = TransmissionRouter(
-                    setOf(transformer1, transformer2, transformer3),
-                    testDispatcher
-                )
+                sut = TransmissionRouterBuilder.build {
+                    withTransformerSet(setOf(transformer1, transformer2, transformer3))
+                    withDispatcher(testDispatcher)
+                }
                 // When
                 val effects = sut.effectStream.testIn(backgroundScope)
                 sut.processSignal(TestSignal)
@@ -133,10 +149,10 @@ class TransmissionRouterTest {
                 val transformer1 = TestTransformer1(testDispatcher)
                 val transformer2 = TestTransformer2(testDispatcher)
                 val transformer3 = TestTransformer3(testDispatcher)
-                sut = TransmissionRouter(
-                    setOf(transformer1, transformer2, transformer3),
-                    testDispatcher
-                )
+                sut = TransmissionRouterBuilder.build {
+                    withTransformerSet(setOf(transformer1, transformer2, transformer3))
+                    withDispatcher(testDispatcher)
+                }
                 // When
                 sut.processSignal(TestSignal)
                 sut.dataStream.test {
@@ -155,7 +171,10 @@ class TransmissionRouterTest {
         val transformer1 = TestTransformer1(testDispatcher)
         val transformer2 = TestTransformer2(testDispatcher)
         val transformer3 = TestTransformer3(testDispatcher)
-        sut = TransmissionRouter(setOf(transformer1, transformer2, transformer3), testDispatcher)
+        sut = TransmissionRouterBuilder.build {
+            withTransformerSet(setOf(transformer1, transformer2, transformer3))
+            withDispatcher(testDispatcher)
+        }
         // When
         sut.processSignal(TestSignal)
 


### PR DESCRIPTION
Current Router implementation only accepts a set of Transformers. Set we provide might change depending on different client logic. `TransformerSetLoader` is added to support this behavior.

On the public API, we only added `withLoader` function. Under the hood, `withTransformerSet` function creates a anonymous loader object and pass it to the `TransmissionRouter`.

```kotlin
interface TransformerSetLoader {
    /**
     * This method loads the transformer set to the [TransmissionRouter]
     */
    suspend fun load(): Set<Transformer>
}
```