### PR TITLE
API Rename

### DIFF
--- a/sample/src/main/java/com/trendyol/transmission/features/colorpicker/ColorPickerTransformer.kt
+++ b/sample/src/main/java/com/trendyol/transmission/features/colorpicker/ColorPickerTransformer.kt
@@ -9,7 +9,7 @@ import com.trendyol.transmission.transformer.handler.effect
 import com.trendyol.transmission.transformer.handler.handlers
 import com.trendyol.transmission.transformer.handler.signal
 import com.trendyol.transmission.transformer.request.Contracts
-import com.trendyol.transmission.transformer.request.data
+import com.trendyol.transmission.transformer.request.dataHolder
 import com.trendyol.transmission.transformer.request.identity
 import com.trendyol.transmission.ui.ColorPickerUiState
 import kotlinx.coroutines.CoroutineDispatcher
@@ -42,6 +42,6 @@ class ColorPickerTransformer @Inject constructor(
     }
 
     companion object {
-        val holderContract = Contracts.data<ColorPickerUiState>("ColorPickerUiState")
+        val holderContract = Contracts.dataHolder<ColorPickerUiState>("ColorPickerUiState")
     }
 }

--- a/sample/src/main/java/com/trendyol/transmission/features/colorpicker/ColorPickerTransformer.kt
+++ b/sample/src/main/java/com/trendyol/transmission/features/colorpicker/ColorPickerTransformer.kt
@@ -5,9 +5,9 @@ import com.trendyol.transmission.features.multioutput.multiOutputTransformerIden
 import com.trendyol.transmission.transformer.Transformer
 import com.trendyol.transmission.transformer.dataholder.dataHolder
 import com.trendyol.transmission.transformer.handler.HandlerRegistry
-import com.trendyol.transmission.transformer.handler.effect
+import com.trendyol.transmission.transformer.handler.onEffect
 import com.trendyol.transmission.transformer.handler.handlers
-import com.trendyol.transmission.transformer.handler.signal
+import com.trendyol.transmission.transformer.handler.onSignal
 import com.trendyol.transmission.transformer.request.Contracts
 import com.trendyol.transmission.transformer.request.dataHolder
 import com.trendyol.transmission.transformer.request.identity
@@ -24,7 +24,7 @@ class ColorPickerTransformer @Inject constructor(
     private val holder = dataHolder(ColorPickerUiState(), holderContract)
 
     override val handlers: HandlerRegistry = handlers {
-        signal<ColorPickerSignal.SelectColor> { signal ->
+        onSignal<ColorPickerSignal.SelectColor> { signal ->
             holder.update { it.copy(selectedColorIndex = signal.index) }
             publish(
                 ColorPickerEffect.BackgroundColorUpdate(signal.selectedColor.copy(alpha = 0.1f))
@@ -34,7 +34,7 @@ class ColorPickerTransformer @Inject constructor(
                 identity = multiOutputTransformerIdentity
             )
         }
-        effect<ColorPickerEffect.BackgroundColorUpdate> { effect ->
+        onEffect<ColorPickerEffect.BackgroundColorUpdate> { effect ->
             holder.update {
                 it.copy(backgroundColor = effect.color)
             }

--- a/sample/src/main/java/com/trendyol/transmission/features/colorpicker/ColorPickerTransformer.kt
+++ b/sample/src/main/java/com/trendyol/transmission/features/colorpicker/ColorPickerTransformer.kt
@@ -3,27 +3,28 @@ package com.trendyol.transmission.features.colorpicker
 import com.trendyol.transmission.DefaultDispatcher
 import com.trendyol.transmission.features.multioutput.multiOutputTransformerIdentity
 import com.trendyol.transmission.transformer.Transformer
-import com.trendyol.transmission.transformer.dataholder.buildDataHolder
+import com.trendyol.transmission.transformer.dataholder.dataHolder
 import com.trendyol.transmission.transformer.handler.HandlerRegistry
-import com.trendyol.transmission.transformer.handler.handlerRegistry
-import com.trendyol.transmission.transformer.handler.registerEffect
-import com.trendyol.transmission.transformer.handler.registerSignal
-import com.trendyol.transmission.transformer.request.buildDataContract
-import com.trendyol.transmission.transformer.request.createIdentity
+import com.trendyol.transmission.transformer.handler.effect
+import com.trendyol.transmission.transformer.handler.handlers
+import com.trendyol.transmission.transformer.handler.signal
+import com.trendyol.transmission.transformer.request.Contracts
+import com.trendyol.transmission.transformer.request.data
+import com.trendyol.transmission.transformer.request.identity
 import com.trendyol.transmission.ui.ColorPickerUiState
 import kotlinx.coroutines.CoroutineDispatcher
 import javax.inject.Inject
 
-val colorPickerIdentity = createIdentity("ColorPicker")
+val colorPickerIdentity = Contracts.identity("ColorPicker")
 
 class ColorPickerTransformer @Inject constructor(
     @DefaultDispatcher private val defaultDispatcher: CoroutineDispatcher
 ) : Transformer(defaultDispatcher, colorPickerIdentity) {
 
-    private val holder = buildDataHolder(ColorPickerUiState(), holderContract)
+    private val holder = dataHolder(ColorPickerUiState(), holderContract)
 
-    override val handlerRegistry: HandlerRegistry = handlerRegistry {
-        registerSignal<ColorPickerSignal.SelectColor> { signal ->
+    override val handlers: HandlerRegistry = handlers {
+        signal<ColorPickerSignal.SelectColor> { signal ->
             holder.update { it.copy(selectedColorIndex = signal.index) }
             publish(
                 ColorPickerEffect.BackgroundColorUpdate(signal.selectedColor.copy(alpha = 0.1f))
@@ -33,7 +34,7 @@ class ColorPickerTransformer @Inject constructor(
                 identity = multiOutputTransformerIdentity
             )
         }
-        registerEffect<ColorPickerEffect.BackgroundColorUpdate> { effect ->
+        effect<ColorPickerEffect.BackgroundColorUpdate> { effect ->
             holder.update {
                 it.copy(backgroundColor = effect.color)
             }
@@ -41,6 +42,6 @@ class ColorPickerTransformer @Inject constructor(
     }
 
     companion object {
-        val holderContract = buildDataContract<ColorPickerUiState>("ColorPickerUiState")
+        val holderContract = Contracts.data<ColorPickerUiState>("ColorPickerUiState")
     }
 }

--- a/sample/src/main/java/com/trendyol/transmission/features/input/InputTransformer.kt
+++ b/sample/src/main/java/com/trendyol/transmission/features/input/InputTransformer.kt
@@ -5,9 +5,9 @@ import com.trendyol.transmission.features.colorpicker.ColorPickerEffect
 import com.trendyol.transmission.transformer.Transformer
 import com.trendyol.transmission.transformer.dataholder.dataHolder
 import com.trendyol.transmission.transformer.handler.HandlerRegistry
-import com.trendyol.transmission.transformer.handler.effect
+import com.trendyol.transmission.transformer.handler.onEffect
 import com.trendyol.transmission.transformer.handler.handlers
-import com.trendyol.transmission.transformer.handler.signal
+import com.trendyol.transmission.transformer.handler.onSignal
 import com.trendyol.transmission.transformer.request.Contracts
 import com.trendyol.transmission.transformer.request.computation
 import com.trendyol.transmission.transformer.request.computation.ComputationRegistry
@@ -38,11 +38,11 @@ class InputTransformer @Inject constructor(
     }
 
     override val handlers: HandlerRegistry = handlers {
-        signal<InputSignal.InputUpdate> { signal ->
+        onSignal<InputSignal.InputUpdate> { signal ->
             holder.update { it.copy(writtenText = signal.value) }
             publish(effect = InputEffect.InputUpdate(signal.value))
         }
-        effect<ColorPickerEffect.BackgroundColorUpdate> { effect ->
+        onEffect<ColorPickerEffect.BackgroundColorUpdate> { effect ->
             holder.update { it.copy(backgroundColor = effect.color) }
         }
     }

--- a/sample/src/main/java/com/trendyol/transmission/features/input/InputTransformer.kt
+++ b/sample/src/main/java/com/trendyol/transmission/features/input/InputTransformer.kt
@@ -14,7 +14,7 @@ import com.trendyol.transmission.transformer.request.computation.ComputationRegi
 import com.trendyol.transmission.transformer.request.computation.computations
 import com.trendyol.transmission.transformer.request.computation.register
 import com.trendyol.transmission.transformer.request.computationWithArgs
-import com.trendyol.transmission.transformer.request.data
+import com.trendyol.transmission.transformer.request.dataHolder
 import com.trendyol.transmission.ui.InputUiState
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.delay
@@ -51,6 +51,6 @@ class InputTransformer @Inject constructor(
         val writtenInputWithArgs =
             Contracts.computationWithArgs<String, WrittenInput>("WrittenInputWithArgs")
         val writtenInputContract = Contracts.computation<WrittenInput>("WrittenInput")
-        val holderContract = Contracts.data<InputUiState>("InputUiState")
+        val holderContract = Contracts.dataHolder<InputUiState>("InputUiState")
     }
 }

--- a/sample/src/main/java/com/trendyol/transmission/features/input/InputTransformer.kt
+++ b/sample/src/main/java/com/trendyol/transmission/features/input/InputTransformer.kt
@@ -3,17 +3,18 @@ package com.trendyol.transmission.features.input
 import com.trendyol.transmission.DefaultDispatcher
 import com.trendyol.transmission.features.colorpicker.ColorPickerEffect
 import com.trendyol.transmission.transformer.Transformer
-import com.trendyol.transmission.transformer.dataholder.buildDataHolder
+import com.trendyol.transmission.transformer.dataholder.dataHolder
 import com.trendyol.transmission.transformer.handler.HandlerRegistry
-import com.trendyol.transmission.transformer.handler.handlerRegistry
-import com.trendyol.transmission.transformer.handler.registerEffect
-import com.trendyol.transmission.transformer.handler.registerSignal
-import com.trendyol.transmission.transformer.request.buildComputationContract
-import com.trendyol.transmission.transformer.request.buildComputationContractWithArgs
-import com.trendyol.transmission.transformer.request.buildDataContract
+import com.trendyol.transmission.transformer.handler.effect
+import com.trendyol.transmission.transformer.handler.handlers
+import com.trendyol.transmission.transformer.handler.signal
+import com.trendyol.transmission.transformer.request.Contracts
+import com.trendyol.transmission.transformer.request.computation
 import com.trendyol.transmission.transformer.request.computation.ComputationRegistry
-import com.trendyol.transmission.transformer.request.computation.computationRegistry
-import com.trendyol.transmission.transformer.request.computation.registerComputation
+import com.trendyol.transmission.transformer.request.computation.computations
+import com.trendyol.transmission.transformer.request.computation.register
+import com.trendyol.transmission.transformer.request.computationWithArgs
+import com.trendyol.transmission.transformer.request.data
 import com.trendyol.transmission.ui.InputUiState
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.delay
@@ -24,32 +25,32 @@ class InputTransformer @Inject constructor(
     @DefaultDispatcher private val defaultDispatcher: CoroutineDispatcher
 ) : Transformer(defaultDispatcher) {
 
-    private val holder = buildDataHolder(InputUiState(), holderContract)
+    private val holder = dataHolder(InputUiState(), holderContract)
 
-    override val computationRegistry: ComputationRegistry = computationRegistry {
-        registerComputation(writtenInputContract) {
+    override val computations: ComputationRegistry = computations {
+        register(writtenInputContract) {
             delay(1.seconds)
             WrittenInput(holder.getValue().writtenText)
         }
-        registerComputation(writtenInputWithArgs) {
+        register(writtenInputWithArgs) {
             WrittenInput(it)
         }
     }
 
-    override val handlerRegistry: HandlerRegistry = handlerRegistry {
-        registerSignal<InputSignal.InputUpdate> { signal ->
+    override val handlers: HandlerRegistry = handlers {
+        signal<InputSignal.InputUpdate> { signal ->
             holder.update { it.copy(writtenText = signal.value) }
             publish(effect = InputEffect.InputUpdate(signal.value))
         }
-        registerEffect<ColorPickerEffect.BackgroundColorUpdate> { effect ->
+        effect<ColorPickerEffect.BackgroundColorUpdate> { effect ->
             holder.update { it.copy(backgroundColor = effect.color) }
         }
     }
 
     companion object {
         val writtenInputWithArgs =
-            buildComputationContractWithArgs<String, WrittenInput>("WrittenInputWithArgs")
-        val writtenInputContract = buildComputationContract<WrittenInput>("WrittenInput")
-        val holderContract = buildDataContract<InputUiState>("InputUiState")
+            Contracts.computationWithArgs<String, WrittenInput>("WrittenInputWithArgs")
+        val writtenInputContract = Contracts.computation<WrittenInput>("WrittenInput")
+        val holderContract = Contracts.data<InputUiState>("InputUiState")
     }
 }

--- a/sample/src/main/java/com/trendyol/transmission/features/multioutput/MultiOutputTransformer.kt
+++ b/sample/src/main/java/com/trendyol/transmission/features/multioutput/MultiOutputTransformer.kt
@@ -5,35 +5,36 @@ import com.trendyol.transmission.features.colorpicker.ColorPickerEffect
 import com.trendyol.transmission.features.input.InputEffect
 import com.trendyol.transmission.features.output.OutputTransformer
 import com.trendyol.transmission.transformer.Transformer
-import com.trendyol.transmission.transformer.dataholder.buildDataHolder
+import com.trendyol.transmission.transformer.dataholder.dataHolder
 import com.trendyol.transmission.transformer.handler.HandlerRegistry
-import com.trendyol.transmission.transformer.handler.handlerRegistry
-import com.trendyol.transmission.transformer.handler.registerEffect
-import com.trendyol.transmission.transformer.request.createIdentity
+import com.trendyol.transmission.transformer.handler.effect
+import com.trendyol.transmission.transformer.handler.handlers
+import com.trendyol.transmission.transformer.request.Contracts
+import com.trendyol.transmission.transformer.request.identity
 import com.trendyol.transmission.ui.MultiOutputUiState
 import kotlinx.coroutines.CoroutineDispatcher
 import javax.inject.Inject
 
-val multiOutputTransformerIdentity = createIdentity("MultiOutput")
+val multiOutputTransformerIdentity = Contracts.identity("MultiOutput")
 
 class MultiOutputTransformer @Inject constructor(
     @DefaultDispatcher private val defaultDispatcher: CoroutineDispatcher
 ) : Transformer(defaultDispatcher, multiOutputTransformerIdentity) {
 
-    private val holder = buildDataHolder(MultiOutputUiState())
+    private val holder = dataHolder(MultiOutputUiState())
 
-    override val handlerRegistry: HandlerRegistry = handlerRegistry {
-        registerEffect<InputEffect.InputUpdate> { effect ->
+    override val handlers: HandlerRegistry = handlers {
+        effect<InputEffect.InputUpdate> { effect ->
             holder.update { it.copy(writtenUppercaseText = effect.value.uppercase()) }
             val result = compute(OutputTransformer.outputCalculationContract)
             holder.update {
                 it.copy(writtenUppercaseText = it.writtenUppercaseText + " ${result?.result}")
             }
         }
-        registerEffect<ColorPickerEffect.BackgroundColorUpdate> { effect ->
+        effect<ColorPickerEffect.BackgroundColorUpdate> { effect ->
             holder.update { it.copy(backgroundColor = effect.color) }
         }
-        registerEffect<ColorPickerEffect.SelectedColorUpdate> { effect ->
+        effect<ColorPickerEffect.SelectedColorUpdate> { effect ->
             holder.update { it.copy(selectedColor = effect.color) }
         }
     }

--- a/sample/src/main/java/com/trendyol/transmission/features/multioutput/MultiOutputTransformer.kt
+++ b/sample/src/main/java/com/trendyol/transmission/features/multioutput/MultiOutputTransformer.kt
@@ -7,7 +7,7 @@ import com.trendyol.transmission.features.output.OutputTransformer
 import com.trendyol.transmission.transformer.Transformer
 import com.trendyol.transmission.transformer.dataholder.dataHolder
 import com.trendyol.transmission.transformer.handler.HandlerRegistry
-import com.trendyol.transmission.transformer.handler.effect
+import com.trendyol.transmission.transformer.handler.onEffect
 import com.trendyol.transmission.transformer.handler.handlers
 import com.trendyol.transmission.transformer.request.Contracts
 import com.trendyol.transmission.transformer.request.identity
@@ -24,17 +24,17 @@ class MultiOutputTransformer @Inject constructor(
     private val holder = dataHolder(MultiOutputUiState())
 
     override val handlers: HandlerRegistry = handlers {
-        effect<InputEffect.InputUpdate> { effect ->
+        onEffect<InputEffect.InputUpdate> { effect ->
             holder.update { it.copy(writtenUppercaseText = effect.value.uppercase()) }
             val result = compute(OutputTransformer.outputCalculationContract)
             holder.update {
                 it.copy(writtenUppercaseText = it.writtenUppercaseText + " ${result?.result}")
             }
         }
-        effect<ColorPickerEffect.BackgroundColorUpdate> { effect ->
+        onEffect<ColorPickerEffect.BackgroundColorUpdate> { effect ->
             holder.update { it.copy(backgroundColor = effect.color) }
         }
-        effect<ColorPickerEffect.SelectedColorUpdate> { effect ->
+        onEffect<ColorPickerEffect.SelectedColorUpdate> { effect ->
             holder.update { it.copy(selectedColor = effect.color) }
         }
     }

--- a/sample/src/main/java/com/trendyol/transmission/features/output/OutputTransformer.kt
+++ b/sample/src/main/java/com/trendyol/transmission/features/output/OutputTransformer.kt
@@ -11,7 +11,7 @@ import com.trendyol.transmission.features.input.InputTransformer
 import com.trendyol.transmission.transformer.Transformer
 import com.trendyol.transmission.transformer.dataholder.dataHolder
 import com.trendyol.transmission.transformer.handler.HandlerRegistry
-import com.trendyol.transmission.transformer.handler.effect
+import com.trendyol.transmission.transformer.handler.onEffect
 import com.trendyol.transmission.transformer.handler.handlers
 import com.trendyol.transmission.transformer.request.Contracts
 import com.trendyol.transmission.transformer.request.computation
@@ -61,11 +61,11 @@ class OutputTransformer @Inject constructor(
     }
 
     override val handlers: HandlerRegistry = handlers {
-        effect<InputEffect.InputUpdate> { effect ->
+        onEffect<InputEffect.InputUpdate> { effect ->
             holder.update { it.copy(outputText = effect.value) }
             delay(3.seconds)
             val selectedColor = getData(ColorPickerTransformer.holderContract)
-            selectedColor ?: return@effect
+            selectedColor ?: return@onEffect
             holder.update {
                 it.copy(outputText = it.outputText + " and Selected color index is ${selectedColor.selectedColorIndex}")
             }
@@ -77,7 +77,7 @@ class OutputTransformer @Inject constructor(
             execute(outputExecutionContract)
             publish(effect = RouterEffect(holder.getValue()))
         }
-        effect<ColorPickerEffect.BackgroundColorUpdate> { effect ->
+        onEffect<ColorPickerEffect.BackgroundColorUpdate> { effect ->
             holder.update { it.copy(backgroundColor = effect.color) }
         }
     }

--- a/transmission/src/main/java/com/trendyol/transmission/router/RequestDelegate.kt
+++ b/transmission/src/main/java/com/trendyol/transmission/router/RequestDelegate.kt
@@ -83,7 +83,7 @@ internal class RequestDelegate(
             val computationData = runCatching {
                 computationHolder?.storage?.getComputationByKey(query.key)
                     ?.getResult(computationHolder.communicationScope, query.invalidate)
-            }.onFailure{
+            }.onFailure {
                 computationHolder?.onError(it)
             }.getOrNull()
 
@@ -117,7 +117,7 @@ internal class RequestDelegate(
                         query.invalidate,
                         query.args
                     )
-            }.onFailure{
+            }.onFailure {
                 computationHolder?.onError(it)
             }.getOrNull()
 
@@ -210,7 +210,7 @@ internal class RequestDelegate(
 
     // region Request Handler
 
-    override suspend fun <C : Contract.Data<D>, D : Transmission.Data> getData(contract: C): D? {
+    override suspend fun <C : Contract.DataHolder<D>, D : Transmission.Data> getData(contract: C): D? {
         outGoingQuery.trySend(
             Query.Data(sender = routerRef.routerName, key = contract.key)
         )

--- a/transmission/src/main/java/com/trendyol/transmission/transformer/CommunicationScopeBuilder.kt
+++ b/transmission/src/main/java/com/trendyol/transmission/transformer/CommunicationScopeBuilder.kt
@@ -28,7 +28,7 @@ internal class CommunicationScopeBuilder(
         effectChannel.trySend(EffectWrapper(effect))
     }
 
-    override suspend fun <C : Contract.Data<D>, D : Transmission.Data> getData(contract: C): D? {
+    override suspend fun <C : Contract.DataHolder<D>, D : Transmission.Data> getData(contract: C): D? {
         return requestDelegate.interactor.getData(contract)
     }
 

--- a/transmission/src/main/java/com/trendyol/transmission/transformer/dataholder/DataHolderExt.kt
+++ b/transmission/src/main/java/com/trendyol/transmission/transformer/dataholder/DataHolderExt.kt
@@ -17,7 +17,7 @@ import com.trendyol.transmission.transformer.request.RequestHandler
  * */
 fun <T : Transmission.Data?> Transformer.dataHolder(
     initialValue: T,
-    contract: Contract.Data<T>? = null,
+    contract: Contract.DataHolder<T>? = null,
     publishUpdates: Boolean = true
 ): TransmissionDataHolder<T> {
     return TransmissionDataHolderBuilder.buildWith(

--- a/transmission/src/main/java/com/trendyol/transmission/transformer/dataholder/DataHolderExt.kt
+++ b/transmission/src/main/java/com/trendyol/transmission/transformer/dataholder/DataHolderExt.kt
@@ -15,7 +15,7 @@ import com.trendyol.transmission.transformer.request.RequestHandler
  * @param [key] When defined, data inside the holder can be accessed by other Transformers in the
  * network using [RequestHandler.query]
  * */
-fun <T : Transmission.Data?> Transformer.buildDataHolder(
+fun <T : Transmission.Data?> Transformer.dataHolder(
     initialValue: T,
     contract: Contract.Data<T>? = null,
     publishUpdates: Boolean = true

--- a/transmission/src/main/java/com/trendyol/transmission/transformer/handler/HandlerRegistry.kt
+++ b/transmission/src/main/java/com/trendyol/transmission/transformer/handler/HandlerRegistry.kt
@@ -16,7 +16,7 @@ class HandlerRegistry internal constructor() {
         mutableMapOf<KClass<out Transmission.Effect>, suspend CommunicationScope.(effect: Transmission.Effect) -> Unit>()
 
     @PublishedApi
-    internal inline fun <reified T : Transmission.Signal> registerSignal(
+    internal inline fun <reified T : Transmission.Signal> signal(
         noinline lambda: suspend CommunicationScope.(signal: T) -> Unit
     ) {
         signalHandlerRegistry[T::class] =
@@ -24,7 +24,7 @@ class HandlerRegistry internal constructor() {
     }
 
     @PublishedApi
-    internal inline fun <reified T : Transmission.Effect> registerEffect(
+    internal inline fun <reified T : Transmission.Effect> effect(
         noinline lambda: suspend CommunicationScope.(effect: T) -> Unit
     ) {
         effectHandlerRegistry[T::class] =

--- a/transmission/src/main/java/com/trendyol/transmission/transformer/handler/HandlerScope.kt
+++ b/transmission/src/main/java/com/trendyol/transmission/transformer/handler/HandlerScope.kt
@@ -11,13 +11,13 @@ fun Transformer.handlers(scope: HandlerScope.() -> Unit): HandlerRegistry {
     return handlerRegistry
 }
 
-inline fun <reified T : Transmission.Effect> HandlerScope.effect(
+inline fun <reified T : Transmission.Effect> HandlerScope.onEffect(
     noinline lambda: suspend CommunicationScope.(effect: T) -> Unit
 ) {
     handlerRegistry.effect<T>(lambda)
 }
 
-inline fun <reified T : Transmission.Signal> HandlerScope.signal(
+inline fun <reified T : Transmission.Signal> HandlerScope.onSignal(
     noinline lambda: suspend CommunicationScope.(signal: T) -> Unit
 ) {
     handlerRegistry.signal<T>(lambda)

--- a/transmission/src/main/java/com/trendyol/transmission/transformer/handler/HandlerScope.kt
+++ b/transmission/src/main/java/com/trendyol/transmission/transformer/handler/HandlerScope.kt
@@ -5,20 +5,20 @@ import com.trendyol.transmission.transformer.Transformer
 
 class HandlerScope internal constructor(val handlerRegistry: HandlerRegistry)
 
-fun Transformer.handlerRegistry(scope: HandlerScope.() -> Unit): HandlerRegistry {
+fun Transformer.handlers(scope: HandlerScope.() -> Unit): HandlerRegistry {
     val handlerRegistry = HandlerRegistry()
     HandlerScope(handlerRegistry).apply(scope)
     return handlerRegistry
 }
 
-inline fun <reified T : Transmission.Effect> HandlerScope.registerEffect(
+inline fun <reified T : Transmission.Effect> HandlerScope.effect(
     noinline lambda: suspend CommunicationScope.(effect: T) -> Unit
 ) {
-    handlerRegistry.registerEffect<T>(lambda)
+    handlerRegistry.effect<T>(lambda)
 }
 
-inline fun <reified T : Transmission.Signal> HandlerScope.registerSignal(
+inline fun <reified T : Transmission.Signal> HandlerScope.signal(
     noinline lambda: suspend CommunicationScope.(signal: T) -> Unit
 ) {
-    handlerRegistry.registerSignal<T>(lambda)
+    handlerRegistry.signal<T>(lambda)
 }

--- a/transmission/src/main/java/com/trendyol/transmission/transformer/request/Contract.kt
+++ b/transmission/src/main/java/com/trendyol/transmission/transformer/request/Contract.kt
@@ -6,7 +6,7 @@ sealed interface Contract {
 
     data class Identity(val key: String) : Contract
 
-    abstract class Data<T : Transmission.Data?> : Contract {
+    abstract class DataHolder<T : Transmission.Data?> : Contract {
         abstract val key: String
     }
 

--- a/transmission/src/main/java/com/trendyol/transmission/transformer/request/ContractExt.kt
+++ b/transmission/src/main/java/com/trendyol/transmission/transformer/request/ContractExt.kt
@@ -2,15 +2,17 @@ package com.trendyol.transmission.transformer.request
 
 import com.trendyol.transmission.Transmission
 
-fun createIdentity(key: String): Contract.Identity = Contract.Identity(key)
+object Contracts
 
-fun <T : Transmission.Data?> buildDataContract(
+fun Contracts.identity(key: String): Contract.Identity = Contract.Identity(key)
+
+fun <T : Transmission.Data?> Contracts.data(
     key: String
 ) = object : Contract.Data<T>() {
     override val key: String = key
 }
 
-fun <A : Any> buildComputationContract(
+fun <A : Any> Contracts.computation(
     key: String,
     useCache: Boolean = false
 ) = object : Contract.Computation<A>() {
@@ -18,7 +20,7 @@ fun <A : Any> buildComputationContract(
     override val useCache: Boolean = useCache
 }
 
-fun <A : Any, T : Any> buildComputationContractWithArgs(
+fun <A : Any, T : Any> Contracts.computationWithArgs(
     key: String,
     useCache: Boolean = false
 ) = object : Contract.ComputationWithArgs<A, T>() {
@@ -26,13 +28,13 @@ fun <A : Any, T : Any> buildComputationContractWithArgs(
     override val useCache: Boolean = useCache
 }
 
-fun buildExecutionContract(
+fun Contracts.execution(
     key: String,
 ) = object : Contract.Execution() {
     override val key: String = key
 }
 
-fun <A : Any> buildExecutionContractWithArgs(
+fun <A : Any> Contracts.executionWithArgs(
     key: String,
 ) = object : Contract.ExecutionWithArgs<A>() {
     override val key: String = key

--- a/transmission/src/main/java/com/trendyol/transmission/transformer/request/ContractExt.kt
+++ b/transmission/src/main/java/com/trendyol/transmission/transformer/request/ContractExt.kt
@@ -6,9 +6,9 @@ object Contracts
 
 fun Contracts.identity(key: String): Contract.Identity = Contract.Identity(key)
 
-fun <T : Transmission.Data?> Contracts.data(
+fun <T : Transmission.Data?> Contracts.dataHolder(
     key: String
-) = object : Contract.Data<T>() {
+) = object : Contract.DataHolder<T>() {
     override val key: String = key
 }
 

--- a/transmission/src/main/java/com/trendyol/transmission/transformer/request/RequestHandler.kt
+++ b/transmission/src/main/java/com/trendyol/transmission/transformer/request/RequestHandler.kt
@@ -4,7 +4,7 @@ import com.trendyol.transmission.Transmission
 
 interface RequestHandler {
 
-    suspend fun <C : Contract.Data<D>, D : Transmission.Data> getData(contract: C): D?
+    suspend fun <C : Contract.DataHolder<D>, D : Transmission.Data> getData(contract: C): D?
 
     suspend fun <C : Contract.Computation<D>, D : Any> compute(
         contract: C,

--- a/transmission/src/main/java/com/trendyol/transmission/transformer/request/TransformerRequestDelegate.kt
+++ b/transmission/src/main/java/com/trendyol/transmission/transformer/request/TransformerRequestDelegate.kt
@@ -15,7 +15,7 @@ internal class TransformerRequestDelegate(scope: CoroutineScope, identity: Contr
 
     val interactor: RequestHandler = object : RequestHandler {
 
-        override suspend fun <C : Contract.Data<D>, D : Transmission.Data> getData(contract: C): D? {
+        override suspend fun <C : Contract.DataHolder<D>, D : Transmission.Data> getData(contract: C): D? {
             outGoingQuery.trySend(Query.Data(sender = identity.key, key = contract.key))
             return resultBroadcast.output
                 .filterIsInstance<QueryResult.Data<D>>()

--- a/transmission/src/main/java/com/trendyol/transmission/transformer/request/computation/ComputationExt.kt
+++ b/transmission/src/main/java/com/trendyol/transmission/transformer/request/computation/ComputationExt.kt
@@ -13,7 +13,7 @@ import com.trendyol.transmission.transformer.request.RequestHandler
  * Can be queried using [RequestHandler.execute]
  * @param computation Computation to get the result [Transmission.Data]
  */
-fun <C : Contract.Computation<T>, T : Any> ComputationScope.registerComputation(
+fun <C : Contract.Computation<T>, T : Any> ComputationScope.register(
     contract: C,
     computation: suspend RequestHandler.() -> T?,
 ) {
@@ -28,7 +28,7 @@ fun <C : Contract.Computation<T>, T : Any> ComputationScope.registerComputation(
  * Can be queried using [RequestHandler.execute]
  * @param computation Computation to get the result [Transmission.Data]
  */
-fun <C : Contract.ComputationWithArgs<A, T>, A : Any, T : Any> ComputationScope.registerComputation(
+fun <C : Contract.ComputationWithArgs<A, T>, A : Any, T : Any> ComputationScope.register(
     contract: C,
     computation: suspend RequestHandler.(args: A) -> T?,
 ) {

--- a/transmission/src/main/java/com/trendyol/transmission/transformer/request/computation/ComputationScope.kt
+++ b/transmission/src/main/java/com/trendyol/transmission/transformer/request/computation/ComputationScope.kt
@@ -4,7 +4,7 @@ import com.trendyol.transmission.transformer.Transformer
 
 class ComputationScope internal constructor(internal val computationRegistry: ComputationRegistry)
 
-fun Transformer.computationRegistry(scope: ComputationScope.() -> Unit): ComputationRegistry {
+fun Transformer.computations(scope: ComputationScope.() -> Unit): ComputationRegistry {
     val computationRegistry = ComputationRegistry(this)
     ComputationScope(computationRegistry).apply(scope)
     return computationRegistry

--- a/transmission/src/main/java/com/trendyol/transmission/transformer/request/execution/ExecutionExt.kt
+++ b/transmission/src/main/java/com/trendyol/transmission/transformer/request/execution/ExecutionExt.kt
@@ -13,7 +13,7 @@ import com.trendyol.transmission.transformer.request.RequestHandler
  * Can be queried using [RequestHandler.execute]
  * @param execution execution to get the result [Transmission.Data]
  */
-fun <C : Contract.Execution> ExecutionScope.registerExecution(
+fun <C : Contract.Execution> ExecutionScope.register(
     contract: C,
     execution: suspend RequestHandler.() -> Unit,
 ) {
@@ -29,7 +29,7 @@ fun <C : Contract.Execution> ExecutionScope.registerExecution(
  * Can be queried using [RequestHandler.execute]
  * @param execution execution to get the result [Transmission.Data]
  */
-fun <C : Contract.ExecutionWithArgs<A>, A : Any> ExecutionScope.registerExecution(
+fun <C : Contract.ExecutionWithArgs<A>, A : Any> ExecutionScope.register(
     contract: C,
     execution: suspend RequestHandler.(args: A) -> Unit,
 ) {

--- a/transmission/src/main/java/com/trendyol/transmission/transformer/request/execution/ExecutionScope.kt
+++ b/transmission/src/main/java/com/trendyol/transmission/transformer/request/execution/ExecutionScope.kt
@@ -4,7 +4,7 @@ import com.trendyol.transmission.transformer.Transformer
 
 class ExecutionScope internal constructor(internal val executionRegistry: ExecutionRegistry)
 
-fun Transformer.executionRegistry(scope: ExecutionScope.() -> Unit): ExecutionRegistry {
+fun Transformer.executions(scope: ExecutionScope.() -> Unit): ExecutionRegistry {
     val executionRegistry = ExecutionRegistry(this)
     ExecutionScope(executionRegistry).apply(scope)
     return executionRegistry

--- a/transmission/src/test/kotlin/com/trendyol/transmission/transformer/FakeTransformer.kt
+++ b/transmission/src/test/kotlin/com/trendyol/transmission/transformer/FakeTransformer.kt
@@ -5,27 +5,26 @@ import com.trendyol.transmission.effect.RouterEffect
 import com.trendyol.transmission.transformer.data.TestData
 import com.trendyol.transmission.transformer.data.TestEffect
 import com.trendyol.transmission.transformer.data.TestSignal
-import com.trendyol.transmission.transformer.dataholder.buildDataHolder
+import com.trendyol.transmission.transformer.dataholder.dataHolder
 import com.trendyol.transmission.transformer.handler.HandlerRegistry
-import com.trendyol.transmission.transformer.handler.handlerRegistry
-import com.trendyol.transmission.transformer.handler.registerEffect
-import com.trendyol.transmission.transformer.handler.registerSignal
+import com.trendyol.transmission.transformer.handler.effect
+import com.trendyol.transmission.transformer.handler.handlers
 import kotlinx.coroutines.CoroutineDispatcher
 
 open class FakeTransformer(dispatcher: CoroutineDispatcher) : Transformer(dispatcher) {
     val signalList = mutableListOf<Transmission.Signal>()
     val effectList = mutableListOf<Transmission.Effect>()
 
-    private val holder = buildDataHolder<TestData?>(null)
+    private val holder = dataHolder<TestData?>(null)
 
-    override val handlerRegistry: HandlerRegistry = handlerRegistry {
-        registerSignal<TestSignal> { signal ->
+    override val handlers: HandlerRegistry = handlers {
+        effect<TestSignal> { signal ->
             signalList.add(signal)
             publish(TestEffect)
             publish(RouterEffect(""))
             holder.update { TestData("update with ${this@FakeTransformer.javaClass.simpleName}") }
         }
-        registerEffect<TestEffect> { effect ->
+        effect<TestEffect> { effect ->
             effectList.add(effect)
         }
     }

--- a/transmission/src/test/kotlin/com/trendyol/transmission/transformer/FakeTransformer.kt
+++ b/transmission/src/test/kotlin/com/trendyol/transmission/transformer/FakeTransformer.kt
@@ -7,7 +7,7 @@ import com.trendyol.transmission.transformer.data.TestEffect
 import com.trendyol.transmission.transformer.data.TestSignal
 import com.trendyol.transmission.transformer.dataholder.dataHolder
 import com.trendyol.transmission.transformer.handler.HandlerRegistry
-import com.trendyol.transmission.transformer.handler.effect
+import com.trendyol.transmission.transformer.handler.onEffect
 import com.trendyol.transmission.transformer.handler.handlers
 import kotlinx.coroutines.CoroutineDispatcher
 
@@ -18,13 +18,13 @@ open class FakeTransformer(dispatcher: CoroutineDispatcher) : Transformer(dispat
     private val holder = dataHolder<TestData?>(null)
 
     override val handlers: HandlerRegistry = handlers {
-        effect<TestSignal> { signal ->
+        onEffect<TestSignal> { signal ->
             signalList.add(signal)
             publish(TestEffect)
             publish(RouterEffect(""))
             holder.update { TestData("update with ${this@FakeTransformer.javaClass.simpleName}") }
         }
-        effect<TestEffect> { effect ->
+        onEffect<TestEffect> { effect ->
             effectList.add(effect)
         }
     }


### PR DESCRIPTION
This MR introduces a simplified function names across the Library.

There are 4 distinct renamings.

- Signal and Effect Handlers
- Computations
- Executions
- Contracts

## Signal and Effect Handlers

Creation of handler blocks were implemented by `handlerRegistry` function. Inside of the scope, we could call either `registerSignal` or `registerEffect`. New versions are below.

```kotlin
// Old
override val handlerRegistry : HandleRegistry = handlerRegistry {
  registerSignal<InputSignal.InputUpdate> {
    // ...
  }
}
// New
override val handlers : HandleRegistry = handlers {
  signal<InputSignal.InputUpdate> {
    // ...
  }
  effect<InputEffect.InputUpdate> {
    // ...
  }
}

```

Also variable that holds the handler lambda blocks is refactored to `handlers`.

## Computations

```kotlin

// Old
override val computationRegistry: ComputationRegistry = computationRegistry {
    registerComputation(outputCalculationContract) {
      // ...
    }
}

// New
override val computations: ComputationRegistry = computations {
    register(outputCalculationContract) {
       // ..
    }
}

```

## Executions

```kotlin
// Old
override val executionRegistry: ExecutionRegistry = executionRegistry {
    registerExecution(outputExecutionContract) {
        // ...
    }
}

// New

override val executions: ExecutionRegistry = executions {
    register(outputExecutionContract) {
      // ...
    }
}
```

## Contracts

To make the contracts more discoverable, Its creation methods are now tied to a `Contracts` object. This simplifies the locating and finding the correct method for adding a Contract to Either Transformer or its handlers, computations or executions.

```kotlin
val outputCalculationContract = Contracts.computation<OutputCalculationResult>("OutputCalculationResult")
val outputExecutionContract = Contracts.execution("outputExecutionContract")

```