### PR TITLE
Extending Transformer Functionality

### DIFF
--- a/sample/src/main/java/com/trendyol/transmission/components/features/colorpicker/ColorPickerTransformer.kt
+++ b/sample/src/main/java/com/trendyol/transmission/components/features/colorpicker/ColorPickerTransformer.kt
@@ -4,14 +4,14 @@ import com.trendyol.transmission.DefaultDispatcher
 import com.trendyol.transmission.components.features.multioutput.multiOutputTransformerIdentity
 import com.trendyol.transmission.transformer.Transformer
 import com.trendyol.transmission.transformer.dataholder.dataHolder
-import com.trendyol.transmission.transformer.handler.HandlerRegistry
-import com.trendyol.transmission.transformer.handler.handlers
+import com.trendyol.transmission.transformer.handler.createHandlers
 import com.trendyol.transmission.transformer.handler.onEffect
 import com.trendyol.transmission.transformer.handler.onSignal
 import com.trendyol.transmission.transformer.request.Contracts
 import com.trendyol.transmission.transformer.request.dataHolder
 import com.trendyol.transmission.transformer.request.identity
 import com.trendyol.transmission.components.features.ColorPickerUiState
+import com.trendyol.transmission.transformer.handler.Handlers
 import kotlinx.coroutines.CoroutineDispatcher
 import javax.inject.Inject
 
@@ -23,7 +23,7 @@ class ColorPickerTransformer @Inject constructor(
 
     private val holder = dataHolder(ColorPickerUiState(), holderContract)
 
-    override val handlers: HandlerRegistry = handlers {
+    override val handlers: Handlers = createHandlers {
         onSignal<ColorPickerSignal.SelectColor> { signal ->
             holder.update { it.copy(selectedColorIndex = signal.index) }
             publish(

--- a/sample/src/main/java/com/trendyol/transmission/components/features/input/InputTransformer.kt
+++ b/sample/src/main/java/com/trendyol/transmission/components/features/input/InputTransformer.kt
@@ -4,18 +4,17 @@ import com.trendyol.transmission.DefaultDispatcher
 import com.trendyol.transmission.components.features.colorpicker.ColorPickerEffect
 import com.trendyol.transmission.transformer.Transformer
 import com.trendyol.transmission.transformer.dataholder.dataHolder
-import com.trendyol.transmission.transformer.handler.HandlerRegistry
-import com.trendyol.transmission.transformer.handler.handlers
+import com.trendyol.transmission.transformer.handler.Handlers
+import com.trendyol.transmission.transformer.handler.createHandlers
 import com.trendyol.transmission.transformer.handler.onEffect
 import com.trendyol.transmission.transformer.handler.onSignal
 import com.trendyol.transmission.transformer.request.Contracts
 import com.trendyol.transmission.transformer.request.computation
-import com.trendyol.transmission.transformer.request.computation.ComputationRegistry
-import com.trendyol.transmission.transformer.request.computation.computations
+import com.trendyol.transmission.transformer.request.computation.Computations
+import com.trendyol.transmission.transformer.request.computation.createComputations
 import com.trendyol.transmission.transformer.request.computation.register
 import com.trendyol.transmission.transformer.request.computationWithArgs
 import com.trendyol.transmission.transformer.request.dataHolder
-import com.trendyol.transmission.transformer.request.identity
 import com.trendyol.transmission.components.features.InputUiState
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.delay
@@ -28,7 +27,7 @@ class InputTransformer @Inject constructor(
 
     private val holder = dataHolder(InputUiState(), holderContract)
 
-    override val computations: ComputationRegistry = computations {
+    override val computations: Computations = createComputations {
         register(writtenInputContract) {
             delay(1.seconds)
             WrittenInput(holder.getValue().writtenText)
@@ -38,7 +37,7 @@ class InputTransformer @Inject constructor(
         }
     }
 
-    override val handlers: HandlerRegistry = handlers {
+    override val handlers: Handlers = createHandlers {
         onSignal<InputSignal.InputUpdate> { signal ->
             holder.update { it.copy(writtenText = signal.value) }
             publish(effect = InputEffect.InputUpdate(signal.value))
@@ -54,3 +53,4 @@ class InputTransformer @Inject constructor(
         val holderContract = Contracts.dataHolder<InputUiState>()
     }
 }
+

--- a/sample/src/main/java/com/trendyol/transmission/components/features/multioutput/MultiOutputTransformer.kt
+++ b/sample/src/main/java/com/trendyol/transmission/components/features/multioutput/MultiOutputTransformer.kt
@@ -1,17 +1,17 @@
 package com.trendyol.transmission.components.features.multioutput
 
 import com.trendyol.transmission.DefaultDispatcher
+import com.trendyol.transmission.components.features.MultiOutputUiState
 import com.trendyol.transmission.components.features.colorpicker.ColorPickerEffect
 import com.trendyol.transmission.components.features.input.InputEffect
 import com.trendyol.transmission.components.features.output.OutputTransformer
 import com.trendyol.transmission.transformer.Transformer
 import com.trendyol.transmission.transformer.dataholder.dataHolder
-import com.trendyol.transmission.transformer.handler.HandlerRegistry
-import com.trendyol.transmission.transformer.handler.handlers
+import com.trendyol.transmission.transformer.handler.Handlers
+import com.trendyol.transmission.transformer.handler.createHandlers
 import com.trendyol.transmission.transformer.handler.onEffect
 import com.trendyol.transmission.transformer.request.Contracts
 import com.trendyol.transmission.transformer.request.identity
-import com.trendyol.transmission.components.features.MultiOutputUiState
 import kotlinx.coroutines.CoroutineDispatcher
 import javax.inject.Inject
 
@@ -23,7 +23,7 @@ class MultiOutputTransformer @Inject constructor(
 
     private val holder = dataHolder(MultiOutputUiState())
 
-    override val handlers: HandlerRegistry = handlers {
+    override val handlers: Handlers = createHandlers {
         onEffect<InputEffect.InputUpdate> { effect ->
             holder.update { it.copy(writtenUppercaseText = effect.value.uppercase()) }
             val result = compute(OutputTransformer.outputCalculationContract)

--- a/sample/src/main/java/com/trendyol/transmission/components/features/output/OutputTransformer.kt
+++ b/sample/src/main/java/com/trendyol/transmission/components/features/output/OutputTransformer.kt
@@ -2,29 +2,28 @@ package com.trendyol.transmission.components.features.output
 
 import android.util.Log
 import com.trendyol.transmission.DefaultDispatcher
-import com.trendyol.transmission.effect.RouterEffect
+import com.trendyol.transmission.components.features.ColorPickerUiState
+import com.trendyol.transmission.components.features.OutputUiState
 import com.trendyol.transmission.components.features.colorpicker.ColorPickerEffect
 import com.trendyol.transmission.components.features.colorpicker.ColorPickerTransformer
 import com.trendyol.transmission.components.features.colorpicker.colorPickerIdentity
 import com.trendyol.transmission.components.features.input.InputEffect
 import com.trendyol.transmission.components.features.input.InputTransformer
+import com.trendyol.transmission.effect.RouterEffect
 import com.trendyol.transmission.transformer.Transformer
 import com.trendyol.transmission.transformer.dataholder.dataHolder
-import com.trendyol.transmission.transformer.handler.HandlerRegistry
-import com.trendyol.transmission.transformer.handler.handlers
+import com.trendyol.transmission.transformer.handler.Handlers
+import com.trendyol.transmission.transformer.handler.createHandlers
 import com.trendyol.transmission.transformer.handler.onEffect
 import com.trendyol.transmission.transformer.request.Contracts
 import com.trendyol.transmission.transformer.request.computation
-import com.trendyol.transmission.transformer.request.computation.ComputationRegistry
-import com.trendyol.transmission.transformer.request.computation.computations
+import com.trendyol.transmission.transformer.request.computation.Computations
+import com.trendyol.transmission.transformer.request.computation.createComputations
 import com.trendyol.transmission.transformer.request.computation.register
 import com.trendyol.transmission.transformer.request.execution
-import com.trendyol.transmission.transformer.request.execution.ExecutionRegistry
-import com.trendyol.transmission.transformer.request.execution.executions
+import com.trendyol.transmission.transformer.request.execution.Executions
+import com.trendyol.transmission.transformer.request.execution.createExecutions
 import com.trendyol.transmission.transformer.request.execution.register
-import com.trendyol.transmission.transformer.request.identity
-import com.trendyol.transmission.components.features.ColorPickerUiState
-import com.trendyol.transmission.components.features.OutputUiState
 import com.trendyol.transmission.ui.theme.Pink80
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.delay
@@ -40,7 +39,7 @@ class OutputTransformer @Inject constructor(
 
     private val holder2 = dataHolder(ColorPickerUiState(), publishUpdates = false)
 
-    override val computations: ComputationRegistry = computations {
+    override val computations: Computations = createComputations {
         register(outputCalculationContract) {
             delay(2.seconds)
             val data = getData(ColorPickerTransformer.holderContract)?.selectedColorIndex
@@ -50,7 +49,7 @@ class OutputTransformer @Inject constructor(
         }
     }
 
-    override val executions: ExecutionRegistry = executions {
+    override val executions: Executions = createExecutions {
         register(outputExecutionContract) {
             delay(4.seconds)
             communicationScope.publish(ColorPickerEffect.BackgroundColorUpdate(Pink80))
@@ -61,7 +60,7 @@ class OutputTransformer @Inject constructor(
         }
     }
 
-    override val handlers: HandlerRegistry = handlers {
+    override val handlers: Handlers = createHandlers {
         onEffect<InputEffect.InputUpdate> { effect ->
             holder.update { it.copy(outputText = effect.value) }
             delay(3.seconds)

--- a/sample/src/main/java/com/trendyol/transmission/counter/Holder.kt
+++ b/sample/src/main/java/com/trendyol/transmission/counter/Holder.kt
@@ -5,7 +5,7 @@ import com.trendyol.transmission.transformer.Transformer
 import com.trendyol.transmission.transformer.dataholder.dataHolder
 import com.trendyol.transmission.transformer.request.Contracts
 import com.trendyol.transmission.transformer.request.computation.ComputationRegistry
-import com.trendyol.transmission.transformer.request.computation.computations
+import com.trendyol.transmission.transformer.request.computation.createComputations
 import com.trendyol.transmission.transformer.request.computation.register
 import com.trendyol.transmission.transformer.request.computationWithArgs
 
@@ -17,7 +17,7 @@ class Holder : Transformer() {
 
     val counterData = dataHolder(TestCounter(0))
 
-    override val computations: ComputationRegistry = computations {
+    override val computationRegistry: ComputationRegistry = createComputations {
         register(lookUpAndReturn) { id ->
             counterData.updateAndGet { it.copy(value = it.value.plus(1)) }.value
         }

--- a/sample/src/main/java/com/trendyol/transmission/counter/Holder.kt
+++ b/sample/src/main/java/com/trendyol/transmission/counter/Holder.kt
@@ -4,7 +4,7 @@ import com.trendyol.transmission.Transmission
 import com.trendyol.transmission.transformer.Transformer
 import com.trendyol.transmission.transformer.dataholder.dataHolder
 import com.trendyol.transmission.transformer.request.Contracts
-import com.trendyol.transmission.transformer.request.computation.ComputationRegistry
+import com.trendyol.transmission.transformer.request.computation.Computations
 import com.trendyol.transmission.transformer.request.computation.createComputations
 import com.trendyol.transmission.transformer.request.computation.register
 import com.trendyol.transmission.transformer.request.computationWithArgs
@@ -17,7 +17,7 @@ class Holder : Transformer() {
 
     val counterData = dataHolder(TestCounter(0))
 
-    override val computationRegistry: ComputationRegistry = createComputations {
+    override val computations: Computations = createComputations {
         register(lookUpAndReturn) { id ->
             counterData.updateAndGet { it.copy(value = it.value.plus(1)) }.value
         }

--- a/sample/src/main/java/com/trendyol/transmission/counter/Worker.kt
+++ b/sample/src/main/java/com/trendyol/transmission/counter/Worker.kt
@@ -2,15 +2,14 @@ package com.trendyol.transmission.counter
 
 import com.trendyol.transmission.transformer.Transformer
 import com.trendyol.transmission.transformer.handler.HandlerRegistry
-import com.trendyol.transmission.transformer.handler.handlers
+import com.trendyol.transmission.transformer.handler.createHandlers
 import com.trendyol.transmission.transformer.handler.onSignal
 
 class Worker(val id: String) : Transformer() {
 
-    override val handlers: HandlerRegistry = handlers {
+    override val handlers: HandlerRegistry = createHandlers {
         onSignal<CounterSignal.Lookup> {
             send(CounterData("Transformer $id updated data to ${compute(lookUpAndReturn, id)}"))
         }
     }
 }
-

--- a/sample/src/main/java/com/trendyol/transmission/counter/Worker.kt
+++ b/sample/src/main/java/com/trendyol/transmission/counter/Worker.kt
@@ -1,13 +1,13 @@
 package com.trendyol.transmission.counter
 
 import com.trendyol.transmission.transformer.Transformer
-import com.trendyol.transmission.transformer.handler.HandlerRegistry
+import com.trendyol.transmission.transformer.handler.Handlers
 import com.trendyol.transmission.transformer.handler.createHandlers
 import com.trendyol.transmission.transformer.handler.onSignal
 
 class Worker(val id: String) : Transformer() {
 
-    override val handlers: HandlerRegistry = createHandlers {
+    override val handlers: Handlers = createHandlers {
         onSignal<CounterSignal.Lookup> {
             send(CounterData("Transformer $id updated data to ${compute(lookUpAndReturn, id)}"))
         }

--- a/transmission/src/main/java/com/trendyol/transmission/router/Broadcast.kt
+++ b/transmission/src/main/java/com/trendyol/transmission/router/Broadcast.kt
@@ -5,7 +5,6 @@ import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.channels.SendChannel
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.SharingStarted
-import kotlinx.coroutines.flow.buffer
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.shareIn
 
@@ -14,12 +13,15 @@ interface Broadcast<T> {
     val output: SharedFlow<T>
 }
 
-fun <T> CoroutineScope.createBroadcast(): Broadcast<T> = object : Broadcast<T> {
+internal fun <T> CoroutineScope.createBroadcast(
+    sharingStarted: SharingStarted = SharingStarted.WhileSubscribed()
+): Broadcast<T> = object : Broadcast<T> {
+
     private val _source = Channel<T>(capacity = Channel.BUFFERED)
     override val producer: SendChannel<T> = _source
 
     override val output by lazy {
         _source.receiveAsFlow()
-            .shareIn(this@createBroadcast, SharingStarted.Lazily)
+            .shareIn(this@createBroadcast, sharingStarted)
     }
 }

--- a/transmission/src/main/java/com/trendyol/transmission/router/TransmissionRouter.kt
+++ b/transmission/src/main/java/com/trendyol/transmission/router/TransmissionRouter.kt
@@ -44,7 +44,7 @@ class TransmissionRouter internal constructor(
 
     val dataStream = dataBroadcast.output
     val effectStream: SharedFlow<Transmission.Effect> = effectBroadcast.output.map { it.effect }
-        .shareIn(routerScope, SharingStarted.Lazily)
+        .shareIn(routerScope, SharingStarted.WhileSubscribed())
 
     private val _requestDelegate = RequestDelegate(
         queryScope = routerScope,

--- a/transmission/src/main/java/com/trendyol/transmission/transformer/TransformerStorage.kt
+++ b/transmission/src/main/java/com/trendyol/transmission/transformer/TransformerStorage.kt
@@ -20,6 +20,14 @@ internal class TransformerStorage {
     private val internalExecutionMap: MutableMap<String, ExecutionOwner> =
         mutableMapOf()
 
+    fun clearComputations() {
+       internalComputationMap.clear()
+    }
+
+    fun clearExecutions() {
+       internalExecutionMap.clear()
+    }
+
     fun isHolderStateInitialized(): Boolean {
         return internalTransmissionHolderSet is HolderState.Initialized
     }

--- a/transmission/src/main/java/com/trendyol/transmission/transformer/handler/HandlerRegistry.kt
+++ b/transmission/src/main/java/com/trendyol/transmission/transformer/handler/HandlerRegistry.kt
@@ -7,6 +7,11 @@ import kotlin.reflect.KClass
 
 class HandlerRegistry internal constructor() {
 
+    internal fun clear() {
+        signalHandlerRegistry.clear()
+        effectHandlerRegistry.clear()
+    }
+
     @PublishedApi
     internal val signalHandlerRegistry =
         mutableMapOf<KClass<out Transmission.Signal>, suspend CommunicationScope.(effect: Transmission.Signal) -> Unit>()

--- a/transmission/src/main/java/com/trendyol/transmission/transformer/handler/HandlerScope.kt
+++ b/transmission/src/main/java/com/trendyol/transmission/transformer/handler/HandlerScope.kt
@@ -9,7 +9,7 @@ class Handlers internal constructor()
 
 class ExtendedHandlers internal constructor()
 
-fun Transformer.extendedHandlers(scope: HandlerScope.() -> Unit): ExtendedHandlers {
+fun Transformer.extendHandlers(scope: HandlerScope.() -> Unit): ExtendedHandlers {
     HandlerScope(handlerRegistry).apply(scope)
     return ExtendedHandlers()
 }

--- a/transmission/src/main/java/com/trendyol/transmission/transformer/handler/HandlerScope.kt
+++ b/transmission/src/main/java/com/trendyol/transmission/transformer/handler/HandlerScope.kt
@@ -5,10 +5,19 @@ import com.trendyol.transmission.transformer.Transformer
 
 class HandlerScope internal constructor(val handlerRegistry: HandlerRegistry)
 
-fun Transformer.handlers(scope: HandlerScope.() -> Unit): HandlerRegistry {
-    val handlerRegistry = HandlerRegistry()
+class Handlers internal constructor()
+
+class ExtendedHandlers internal constructor()
+
+fun Transformer.extendedHandlers(scope: HandlerScope.() -> Unit): ExtendedHandlers {
     HandlerScope(handlerRegistry).apply(scope)
-    return handlerRegistry
+    return ExtendedHandlers()
+}
+
+fun Transformer.createHandlers(scope: HandlerScope.() -> Unit): Handlers {
+    this.handlerRegistry.clear()
+    HandlerScope(handlerRegistry).apply(scope)
+    return Handlers()
 }
 
 inline fun <reified T : Transmission.Effect> HandlerScope.onEffect(

--- a/transmission/src/main/java/com/trendyol/transmission/transformer/request/computation/ComputationRegistry.kt
+++ b/transmission/src/main/java/com/trendyol/transmission/transformer/request/computation/ComputationRegistry.kt
@@ -3,7 +3,11 @@ package com.trendyol.transmission.transformer.request.computation
 import com.trendyol.transmission.transformer.Transformer
 import com.trendyol.transmission.transformer.request.RequestHandler
 
-class ComputationRegistry internal constructor(private val transformer: Transformer) {
+internal class ComputationRegistry internal constructor(private val transformer: Transformer) {
+
+    internal fun clear() {
+        transformer.storage.clearComputations()
+    }
 
     internal fun <T : Any> buildWith(
         key: String,

--- a/transmission/src/main/java/com/trendyol/transmission/transformer/request/computation/ComputationScope.kt
+++ b/transmission/src/main/java/com/trendyol/transmission/transformer/request/computation/ComputationScope.kt
@@ -4,8 +4,17 @@ import com.trendyol.transmission.transformer.Transformer
 
 class ComputationScope internal constructor(internal val computationRegistry: ComputationRegistry)
 
-fun Transformer.computations(scope: ComputationScope.() -> Unit): ComputationRegistry {
-    val computationRegistry = ComputationRegistry(this)
+class Computations internal constructor()
+
+class ExtendedComputations internal constructor()
+
+fun Transformer.createComputations(scope: ComputationScope.() -> Unit): Computations {
+    this.computationRegistry.clear()
     ComputationScope(computationRegistry).apply(scope)
-    return computationRegistry
+    return Computations()
+}
+
+fun Transformer.extendComputations(scope: ComputationScope.() -> Unit): ExtendedComputations {
+    ComputationScope(computationRegistry).apply(scope)
+    return ExtendedComputations()
 }

--- a/transmission/src/main/java/com/trendyol/transmission/transformer/request/execution/ExecutionRegistry.kt
+++ b/transmission/src/main/java/com/trendyol/transmission/transformer/request/execution/ExecutionRegistry.kt
@@ -5,6 +5,10 @@ import com.trendyol.transmission.transformer.request.RequestHandler
 
 class ExecutionRegistry internal constructor(private val transformer: Transformer) {
 
+    internal fun clear() {
+        transformer.storage.clearExecutions()
+    }
+
     internal fun buildWith(
         key: String,
         execution: suspend RequestHandler.() -> Unit

--- a/transmission/src/main/java/com/trendyol/transmission/transformer/request/execution/ExecutionScope.kt
+++ b/transmission/src/main/java/com/trendyol/transmission/transformer/request/execution/ExecutionScope.kt
@@ -4,8 +4,17 @@ import com.trendyol.transmission.transformer.Transformer
 
 class ExecutionScope internal constructor(internal val executionRegistry: ExecutionRegistry)
 
-fun Transformer.executions(scope: ExecutionScope.() -> Unit): ExecutionRegistry {
-    val executionRegistry = ExecutionRegistry(this)
+class Executions internal constructor()
+
+class ExtendedExecutions internal constructor()
+
+fun Transformer.createExecutions(scope: ExecutionScope.() -> Unit): Executions {
+    this.executionRegistry.clear()
     ExecutionScope(executionRegistry).apply(scope)
-    return executionRegistry
+    return Executions()
+}
+
+fun Transformer.extendExecutions(scope: ExecutionScope.() -> Unit): ExtendedExecutions {
+    ExecutionScope(executionRegistry).apply(scope)
+    return ExtendedExecutions()
 }

--- a/transmission/src/test/kotlin/com/trendyol/transmission/transformer/FakeTransformer.kt
+++ b/transmission/src/test/kotlin/com/trendyol/transmission/transformer/FakeTransformer.kt
@@ -6,8 +6,8 @@ import com.trendyol.transmission.transformer.data.TestData
 import com.trendyol.transmission.transformer.data.TestEffect
 import com.trendyol.transmission.transformer.data.TestSignal
 import com.trendyol.transmission.transformer.dataholder.dataHolder
-import com.trendyol.transmission.transformer.handler.HandlerRegistry
-import com.trendyol.transmission.transformer.handler.handlers
+import com.trendyol.transmission.transformer.handler.Handlers
+import com.trendyol.transmission.transformer.handler.createHandlers
 import com.trendyol.transmission.transformer.handler.onEffect
 import com.trendyol.transmission.transformer.handler.onSignal
 import kotlinx.coroutines.CoroutineDispatcher
@@ -17,9 +17,10 @@ open class FakeTransformer(dispatcher: CoroutineDispatcher) :
     val signalList = mutableListOf<Transmission.Signal>()
     val effectList = mutableListOf<Transmission.Effect>()
 
+
     private val holder = dataHolder<TestData?>(null)
 
-    override val handlers: HandlerRegistry = handlers {
+    override val handlers: Handlers = createHandlers {
         onSignal<TestSignal> { signal ->
             signalList.add(signal)
             publish(TestEffect)


### PR DESCRIPTION
This MR introduces a new way to create and extend handlers, computations and executions for Transformers.

To improve the API's discoverability, `handlerRegistry`, `computationRegistry`, and `executionRegistry` are refactored to `Handlers`, `Computations`, and `Executions`.

Similarly, if you need to extend the Current Transformer functionality, you can override the additional variables with the `extend` prefix. 

Here is a normal definition:

```kotlin

// ... code

override val handlers: Handlers = createHandlers {
        onSignal<InputSignal.InputUpdate> { signal ->
            holder.update { it.copy(writtenText = signal.value) }
            publish(effect = InputEffect.InputUpdate(signal.value))
        }
        onEffect<ColorPickerEffect.BackgroundColorUpdate> { effect ->
            holder.update { it.copy(backgroundColor = effect.color) }
        }
}

// ... code
```

Here is extending the current Transformer's functionality

```kotlin

// ... code

override val extendedHandlers: ExtendedHandlers = extendHandlers {
    onSignal<InputSignal.InputUpdate> { signal ->
        holder.update { it.copy(writtenText = signal.value) }
        publish(effect = InputEffect.InputUpdate(signal.value))
    }
}

```
