### PR TITLE
Experimental Checkpoint testing

### DIFF
--- a/sample/src/test/java/com/trendyol/transmission/features/input/InputTransformerTest.kt
+++ b/sample/src/test/java/com/trendyol/transmission/features/input/InputTransformerTest.kt
@@ -30,7 +30,6 @@ class InputTransformerTest {
     fun `GIVEN inputTransformer, WHEN inputUpdate signal is sent, THEN inputUpdate effect is published`() {
         sut.attachToRouter()
             .registerCheckpoint(InputTransformer.colorCheckpoint, Color.Gray)
-            .validateForTest(InputTransformer.colorCheckpoint)
             .test(signal = InputSignal.InputUpdate("test")) {
                 assertEquals(InputEffect.InputUpdate("test"), effectStream.last())
                 assertEquals(InputUiState("test"), dataStream.last())

--- a/sample/src/test/java/com/trendyol/transmission/features/input/InputTransformerTest.kt
+++ b/sample/src/test/java/com/trendyol/transmission/features/input/InputTransformerTest.kt
@@ -1,6 +1,7 @@
 package com.trendyol.transmission.features.input
 
 import androidx.compose.ui.graphics.Color
+import com.trendyol.transmission.ExperimentalTransmissionApi
 import com.trendyol.transmission.components.features.input.InputEffect
 import com.trendyol.transmission.components.features.input.InputSignal
 import com.trendyol.transmission.components.features.colorpicker.ColorPickerEffect
@@ -26,6 +27,7 @@ class InputTransformerTest {
         sut = InputTransformer(testCoroutineRule.testDispatcher)
     }
 
+    @OptIn(ExperimentalTransmissionApi::class)
     @Test
     fun `GIVEN inputTransformer, WHEN inputUpdate signal is sent, THEN inputUpdate effect is published`() {
         sut.attachToRouter()

--- a/sample/src/test/java/com/trendyol/transmission/features/input/InputTransformerTest.kt
+++ b/sample/src/test/java/com/trendyol/transmission/features/input/InputTransformerTest.kt
@@ -29,8 +29,10 @@ class InputTransformerTest {
     @Test
     fun `GIVEN inputTransformer, WHEN inputUpdate signal is sent, THEN inputUpdate effect is published`() {
         sut.attachToRouter()
+            .registerCheckpoint(InputTransformer.colorCheckpoint, Color.Gray)
+            .validateForTest(InputTransformer.colorCheckpoint)
             .test(signal = InputSignal.InputUpdate("test")) {
-                assertEquals(InputEffect.InputUpdate("test"), effectStream.first())
+                assertEquals(InputEffect.InputUpdate("test"), effectStream.last())
                 assertEquals(InputUiState("test"), dataStream.last())
             }
     }

--- a/transmission-test/src/main/java/com/trendyol/transmissiontest/TestSuite.kt
+++ b/transmission-test/src/main/java/com/trendyol/transmissiontest/TestSuite.kt
@@ -61,26 +61,18 @@ class TestSuite {
         args: A
     ): TestSuite {
         supplementaryTransformerSet += CheckpointWithArgsTransformer<C, A>(checkpoint, { args })
+        orderedCheckpoints.plusAssign(checkpoint)
         return this
     }
 
     fun registerCheckpoint(checkpoint: Contract.Checkpoint.Default): TestSuite {
         supplementaryTransformerSet += CheckpointTransformer({ checkpoint })
+        orderedCheckpoints.plusAssign(checkpoint)
         return this
     }
 
-    fun processBeforeTest(vararg transmissions: Transmission): TestSuite {
+    fun prerequisites(vararg transmissions: Transmission): TestSuite {
         orderedInitialProcessing += transmissions.toList()
-        return this
-    }
-
-    fun <C : Contract.Checkpoint.WithArgs<A>, A : Any> validateForTest(checkpoint: C): TestSuite {
-        orderedCheckpoints.plusAssign(checkpoint)
-        return this
-    }
-
-    fun validateForTest(checkpoint: Contract.Checkpoint.Default): TestSuite {
-        orderedCheckpoints.plusAssign(checkpoint)
         return this
     }
 

--- a/transmission-test/src/main/java/com/trendyol/transmissiontest/TestSuite.kt
+++ b/transmission-test/src/main/java/com/trendyol/transmissiontest/TestSuite.kt
@@ -1,5 +1,6 @@
 package com.trendyol.transmissiontest
 
+import com.trendyol.transmission.ExperimentalTransmissionApi
 import com.trendyol.transmission.Transmission
 import com.trendyol.transmission.router.TransmissionRouter
 import com.trendyol.transmission.router.builder.TransmissionRouterBuilder
@@ -56,6 +57,7 @@ class TestSuite {
         return this
     }
 
+    @ExperimentalTransmissionApi
     fun <C : Contract.Checkpoint.WithArgs<A>, A : Any> registerCheckpoint(
         checkpoint: C,
         args: A
@@ -65,6 +67,7 @@ class TestSuite {
         return this
     }
 
+    @ExperimentalTransmissionApi
     fun registerCheckpoint(checkpoint: Contract.Checkpoint.Default): TestSuite {
         supplementaryTransformerSet += CheckpointTransformer({ checkpoint })
         orderedCheckpoints.plusAssign(checkpoint)

--- a/transmission-test/src/main/java/com/trendyol/transmissiontest/checkpoint/CheckpointTestTransmission.kt
+++ b/transmission-test/src/main/java/com/trendyol/transmissiontest/checkpoint/CheckpointTestTransmission.kt
@@ -1,0 +1,11 @@
+package com.trendyol.transmissiontest.checkpoint
+
+import com.trendyol.transmission.Transmission
+import com.trendyol.transmission.transformer.request.Contract
+
+
+data object DefaultCheckPoint : Transmission.Signal
+
+data class CheckpointWithArgs<C : Contract.Checkpoint.WithArgs<A>, A : Any>(
+    val checkpoint: C,
+) : Transmission.Signal

--- a/transmission-test/src/main/java/com/trendyol/transmissiontest/checkpoint/CheckpointTransformer.kt
+++ b/transmission-test/src/main/java/com/trendyol/transmissiontest/checkpoint/CheckpointTransformer.kt
@@ -1,0 +1,23 @@
+package com.trendyol.transmissiontest.checkpoint
+
+import com.trendyol.transmission.ExperimentalTransmissionApi
+import com.trendyol.transmission.transformer.Transformer
+import com.trendyol.transmission.transformer.handler.Handlers
+import com.trendyol.transmission.transformer.handler.createHandlers
+import com.trendyol.transmission.transformer.handler.onEffect
+import com.trendyol.transmission.transformer.handler.onSignal
+import com.trendyol.transmission.transformer.request.Contract
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+
+@OptIn(ExperimentalCoroutinesApi::class)
+internal class CheckpointTransformer(
+    checkpointProvider: () -> Contract.Checkpoint.Default
+): Transformer(dispatcher = UnconfinedTestDispatcher()) {
+    @OptIn(ExperimentalTransmissionApi::class)
+    override val handlers: Handlers = createHandlers {
+        onSignal<DefaultCheckPoint> {
+            validate(checkpointProvider())
+        }
+    }
+}

--- a/transmission-test/src/main/java/com/trendyol/transmissiontest/checkpoint/CheckpointWithArgsTransformer.kt
+++ b/transmission-test/src/main/java/com/trendyol/transmissiontest/checkpoint/CheckpointWithArgsTransformer.kt
@@ -1,0 +1,22 @@
+package com.trendyol.transmissiontest.checkpoint
+
+import com.trendyol.transmission.ExperimentalTransmissionApi
+import com.trendyol.transmission.transformer.Transformer
+import com.trendyol.transmission.transformer.handler.Handlers
+import com.trendyol.transmission.transformer.handler.createHandlers
+import com.trendyol.transmission.transformer.handler.onSignal
+import com.trendyol.transmission.transformer.request.Contract
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+
+@OptIn(ExperimentalCoroutinesApi::class)
+internal class CheckpointWithArgsTransformer<C: Contract.Checkpoint.WithArgs<A>, A: Any>(
+    checkpoint: C, args: () -> A
+): Transformer(dispatcher = UnconfinedTestDispatcher()) {
+    @OptIn(ExperimentalTransmissionApi::class)
+    override val handlers: Handlers = createHandlers {
+        onSignal<CheckpointWithArgs<C, A>> {
+            validate(checkpoint, args())
+        }
+    }
+}


### PR DESCRIPTION
Checkpoint API is still experimental. This MR introduces the complementary testing counter.

Basic premise is to create a Transformer for sending the validation signals.

```kotlin
internal class CheckpointTransformer(
    checkpointProvider: () -> Contract.Checkpoint.Default
): Transformer(dispatcher = UnconfinedTestDispatcher()) {
    @OptIn(ExperimentalTransmissionApi::class)
    override val handlers: Handlers = createHandlers {
        onSignal<DefaultCheckPoint> {
            validate(checkpointProvider())
        }
    }
}
```

By registering the checkpoint to the TestSuite using `registerCheckpoint`, we call checkpoint at the point of processing the signal/effect and make the suspension point resume.

```kotlin
    @OptIn(ExperimentalTransmissionApi::class)
    @Test
    fun `GIVEN inputTransformer, WHEN inputUpdate signal is sent, THEN inputUpdate effect is published`() {
        sut.attachToRouter()
            .registerCheckpoint(InputTransformer.colorCheckpoint, Color.Gray)
            .test(signal = InputSignal.InputUpdate("test")) {
                assertEquals(InputEffect.InputUpdate("test"), effectStream.last())
                assertEquals(InputUiState("test"), dataStream.last())
            }
    }

```

