### PR TITLE
Additional transformer api

### DIFF
--- a/sample/src/main/java/com/trendyol/transmission/components/features/colorpicker/ColorPickerTransformer.kt
+++ b/sample/src/main/java/com/trendyol/transmission/components/features/colorpicker/ColorPickerTransformer.kt
@@ -4,6 +4,7 @@ import com.trendyol.transmission.DefaultDispatcher
 import com.trendyol.transmission.components.features.ColorPickerUiState
 import com.trendyol.transmission.components.features.multioutput.multiOutputTransformerIdentity
 import com.trendyol.transmission.transformer.Transformer
+import com.trendyol.transmission.transformer.addHandlers
 import com.trendyol.transmission.transformer.dataholder.dataHolder
 import com.trendyol.transmission.transformer.handler.Handlers
 import com.trendyol.transmission.transformer.handler.handlers
@@ -21,20 +22,22 @@ class ColorPickerTransformer @Inject constructor(
 
     private val holder = dataHolder(ColorPickerUiState(), holderContract)
 
-    override val handlers: Handlers = handlers {
-        onSignal<ColorPickerSignal.SelectColor> { signal ->
-            holder.update { it.copy(selectedColorIndex = signal.index) }
-            publish(
-                ColorPickerEffect.BackgroundColorUpdate(signal.selectedColor.copy(alpha = 0.1f))
-            )
-            send(
-                effect = ColorPickerEffect.SelectedColorUpdate(signal.selectedColor),
-                identity = multiOutputTransformerIdentity
-            )
-        }
-        onEffect<ColorPickerEffect.BackgroundColorUpdate> { effect ->
-            holder.update {
-                it.copy(backgroundColor = effect.color)
+    init {
+        addHandlers {
+            onSignal<ColorPickerSignal.SelectColor> { signal ->
+                holder.update { it.copy(selectedColorIndex = signal.index) }
+                publish(
+                    ColorPickerEffect.BackgroundColorUpdate(signal.selectedColor.copy(alpha = 0.1f))
+                )
+                send(
+                    effect = ColorPickerEffect.SelectedColorUpdate(signal.selectedColor),
+                    identity = multiOutputTransformerIdentity
+                )
+            }
+            onEffect<ColorPickerEffect.BackgroundColorUpdate> { effect ->
+                holder.update {
+                    it.copy(backgroundColor = effect.color)
+                }
             }
         }
     }

--- a/sample/src/main/java/com/trendyol/transmission/components/features/output/OutputTransformer.kt
+++ b/sample/src/main/java/com/trendyol/transmission/components/features/output/OutputTransformer.kt
@@ -11,8 +11,12 @@ import com.trendyol.transmission.components.features.input.InputEffect
 import com.trendyol.transmission.components.features.input.InputTransformer
 import com.trendyol.transmission.effect.RouterEffect
 import com.trendyol.transmission.transformer.Transformer
+import com.trendyol.transmission.transformer.addComputations
+import com.trendyol.transmission.transformer.addExecutions
+import com.trendyol.transmission.transformer.addHandlers
 import com.trendyol.transmission.transformer.dataholder.dataHolder
 import com.trendyol.transmission.transformer.handler.Handlers
+import com.trendyol.transmission.transformer.handler.extendEffect
 import com.trendyol.transmission.transformer.handler.handlers
 import com.trendyol.transmission.transformer.handler.onEffect
 import com.trendyol.transmission.transformer.request.Contract
@@ -22,6 +26,7 @@ import com.trendyol.transmission.transformer.request.computation.register
 import com.trendyol.transmission.transformer.request.execution.Executions
 import com.trendyol.transmission.transformer.request.execution.executions
 import com.trendyol.transmission.transformer.request.execution.register
+import com.trendyol.transmission.transformer.updateHandlers
 import com.trendyol.transmission.ui.theme.Pink80
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.delay
@@ -38,46 +43,46 @@ class OutputTransformer @Inject constructor(
 
     private val holder2 = dataHolder(ColorPickerUiState(), publishUpdates = false)
 
-    override val computations: Computations = computations {
-        register(outputCalculationContract) {
-            delay(2.seconds)
-            val data = getData(ColorPickerTransformer.holderContract)?.selectedColorIndex
-            val writtenOutput = compute(InputTransformer.writtenInputContract)
-            val result = Random.nextInt(5, 15) * Random.nextInt(5, 15)
-            OutputCalculationResult("result is $result with ($writtenOutput) and $data")
-        }
-    }
-
-    override val executions: Executions = executions {
-        register(outputExecutionContract) {
-            delay(4.seconds)
-            communicationScope.publish(ColorPickerEffect.BackgroundColorUpdate(Pink80))
-            throw RuntimeException(
-                "This exception will be properly handled and caught " +
-                        "inside of the onError() function"
-            )
-        }
-    }
-
-    override val handlers: Handlers = handlers {
-        onEffect<InputEffect.InputUpdate> { effect ->
-            holder.update { it.copy(outputText = effect.value) }
-            delay(3.seconds)
-            val selectedColor = getData(ColorPickerTransformer.holderContract)
-            selectedColor ?: return@onEffect
-            holder.update {
-                it.copy(outputText = it.outputText + " and Selected color index is ${selectedColor.selectedColorIndex}")
+    init {
+        addComputations {
+            register(outputCalculationContract) {
+                delay(2.seconds)
+                val data = getData(ColorPickerTransformer.holderContract)?.selectedColorIndex
+                val writtenOutput = compute(InputTransformer.writtenInputContract)
+                val result = Random.nextInt(5, 15) * Random.nextInt(5, 15)
+                OutputCalculationResult("result is $result with ($writtenOutput) and $data")
             }
-            delay(1.seconds)
-            send(
-                effect = ColorPickerEffect.BackgroundColorUpdate(holder2.getValue().backgroundColor),
-                identity = colorPickerIdentity
-            )
-            execute(outputExecutionContract)
-            publish(effect = RouterEffect(holder.getValue()))
         }
-        onEffect<ColorPickerEffect.BackgroundColorUpdate> { effect ->
-            holder.update { it.copy(backgroundColor = effect.color) }
+        addExecutions {
+            register(outputExecutionContract) {
+                delay(4.seconds)
+                communicationScope.publish(ColorPickerEffect.BackgroundColorUpdate(Pink80))
+                throw RuntimeException(
+                    "This exception will be properly handled and caught " +
+                            "inside of the onError() function"
+                )
+            }
+        }
+        addHandlers {
+            onEffect<InputEffect.InputUpdate> { effect ->
+                holder.update { it.copy(outputText = effect.value) }
+                delay(3.seconds)
+                val selectedColor = getData(ColorPickerTransformer.holderContract)
+                selectedColor ?: return@onEffect
+                holder.update {
+                    it.copy(outputText = it.outputText + " and Selected color index is ${selectedColor.selectedColorIndex}")
+                }
+                delay(1.seconds)
+                send(
+                    effect = ColorPickerEffect.BackgroundColorUpdate(holder2.getValue().backgroundColor),
+                    identity = colorPickerIdentity
+                )
+                execute(outputExecutionContract)
+                publish(effect = RouterEffect(holder.getValue()))
+            }
+            onEffect<ColorPickerEffect.BackgroundColorUpdate> { effect ->
+                holder.update { it.copy(backgroundColor = effect.color) }
+            }
         }
     }
 

--- a/transmission-test/build.gradle.kts
+++ b/transmission-test/build.gradle.kts
@@ -28,7 +28,7 @@ publishing {
         create<MavenPublication>("release") {
             groupId = "com.trendyol"
             artifactId = "transmission-test"
-            version = "1.4.0"
+            version = "1.4.1"
             afterEvaluate {
                 from(components["java"])
             }

--- a/transmission/build.gradle.kts
+++ b/transmission/build.gradle.kts
@@ -29,7 +29,7 @@ publishing {
         create<MavenPublication>("release") {
             groupId = "com.trendyol"
             artifactId = "transmission"
-            version = "1.4.0"
+            version = "1.4.1"
             afterEvaluate {
                 from(components["java"])
             }

--- a/transmission/src/main/java/com/trendyol/transmission/transformer/TransformerHandlerExt.kt
+++ b/transmission/src/main/java/com/trendyol/transmission/transformer/TransformerHandlerExt.kt
@@ -1,0 +1,219 @@
+package com.trendyol.transmission.transformer
+
+import com.trendyol.transmission.Transmission
+import com.trendyol.transmission.transformer.handler.CommunicationScope
+import com.trendyol.transmission.transformer.handler.HandlerScope
+import com.trendyol.transmission.transformer.handler.UpdateHandlerScope
+import com.trendyol.transmission.transformer.handler.extendEffect
+import com.trendyol.transmission.transformer.handler.extendSignal
+import com.trendyol.transmission.transformer.handler.overrideEffect
+import com.trendyol.transmission.transformer.handler.overrideSignal
+import com.trendyol.transmission.transformer.request.Contract
+import com.trendyol.transmission.transformer.request.QueryHandler
+import com.trendyol.transmission.transformer.request.computation.ComputationScope
+import com.trendyol.transmission.transformer.request.computation.register
+import com.trendyol.transmission.transformer.request.execution.ExecutionScope
+import com.trendyol.transmission.transformer.request.execution.register
+
+/**
+ * Adds handlers incrementally to a Transformer without clearing existing handlers.
+ * This is useful for defining handlers in the init block or in functions.
+ *
+ * Example usage:
+ * ```
+ * class MyTransformer : Transformer() {
+ *     private val holder = dataHolder(MyData())
+ *
+ *     init {
+ *         addHandlers {
+ *             onSignal<MySignal> { signal ->
+ *                 // Handle signal
+ *             }
+ *             onEffect<MyEffect> { effect ->
+ *                 // Handle effect
+ *             }
+ *         }
+ *     }
+ * }
+ * ```
+ */
+fun Transformer.addHandlers(scope: HandlerScope.() -> Unit): Transformer {
+    HandlerScope(handlerRegistry).apply(scope)
+    return this
+}
+
+/**
+ * Updates existing handlers in a Transformer without clearing them.
+ * This allows extending or overriding existing handler implementations.
+ *
+ * Example usage:
+ * ```
+ * class MyTransformer : Transformer() {
+ *     private val holder = dataHolder(MyData())
+ *
+ *     init {
+ *         // Define initial handlers
+ *         handlers { ... }
+ *
+ *         // Later, extend or override handlers
+ *         updateHandlers {
+ *             extendEffect<MyEffect> { effect ->
+ *                 // Additional handling for the effect
+ *             }
+ *
+ *             overrideSignal<MySignal> { signal ->
+ *                 // Completely replace handling for the signal
+ *             }
+ *         }
+ *     }
+ * }
+ * ```
+ */
+fun Transformer.updateHandlers(scope: UpdateHandlerScope.() -> Unit): Transformer {
+    UpdateHandlerScope(handlerRegistry).apply(scope)
+    return this
+}
+
+/**
+ * Functions for adding computations incrementally to a Transformer.
+ * This is useful for defining computations in the init block or in functions.
+ *
+ * Example usage:
+ * ```
+ * class MyTransformer : Transformer() {
+ *     init {
+ *         addComputations {
+ *             register(myComputationContract) {
+ *                 // Compute something
+ *             }
+ *         }
+ *     }
+ * }
+ * ```
+ */
+fun Transformer.addComputations(scope: ComputationScope.() -> Unit): Transformer {
+    ComputationScope(computationRegistry).apply(scope)
+    return this
+}
+
+/**
+ * Functions for adding executions incrementally to a Transformer.
+ * This is useful for defining executions in the init block or in functions.
+ *
+ * Example usage:
+ * ```
+ * class MyTransformer : Transformer() {
+ *     init {
+ *         addExecutions {
+ *             register(myExecutionContract) {
+ *                 // Execute something
+ *             }
+ *         }
+ *     }
+ * }
+ * ```
+ */
+fun Transformer.addExecutions(scope: ExecutionScope.() -> Unit): Transformer {
+    ExecutionScope(executionRegistry).apply(scope)
+    return this
+}
+
+/**
+ * Convenience extension to register a computation directly to a Transformer.
+ */
+fun <C : Contract.Computation<T>, T : Any?> Transformer.registerComputation(
+    contract: C,
+    computation: suspend QueryHandler.() -> T
+): Transformer {
+    addComputations {
+        register(contract, computation)
+    }
+    return this
+}
+
+/**
+ * Convenience extension to register a computation with arguments directly to a Transformer.
+ */
+fun <C : Contract.ComputationWithArgs<A, T>, A : Any, T : Any?> Transformer.registerComputation(
+    contract: C,
+    computation: suspend QueryHandler.(args: A) -> T
+): Transformer {
+    addComputations {
+        register(contract, computation)
+    }
+    return this
+}
+
+/**
+ * Convenience extension to register an execution directly to a Transformer.
+ */
+fun Transformer.registerExecution(
+    contract: Contract.Execution,
+    execution: suspend QueryHandler.() -> Unit
+): Transformer {
+    addExecutions {
+        register(contract, execution)
+    }
+    return this
+}
+
+/**
+ * Convenience extension to register an execution with arguments directly to a Transformer.
+ */
+fun <C : Contract.ExecutionWithArgs<A>, A : Any> Transformer.registerExecution(
+    contract: C,
+    execution: suspend QueryHandler.(args: A) -> Unit
+): Transformer {
+    addExecutions {
+        register(contract, execution)
+    }
+    return this
+}
+
+/**
+ * Convenience extension to extend an existing effect handler in a Transformer.
+ */
+inline fun <reified T : Transmission.Effect> Transformer.extendEffectHandler(
+    noinline lambda: suspend CommunicationScope.(effect: T) -> Unit
+): Transformer {
+    updateHandlers {
+        extendEffect(lambda)
+    }
+    return this
+}
+
+/**
+ * Convenience extension to override an existing effect handler in a Transformer.
+ */
+inline fun <reified T : Transmission.Effect> Transformer.overrideEffectHandler(
+    noinline lambda: suspend CommunicationScope.(effect: T) -> Unit
+): Transformer {
+    updateHandlers {
+        overrideEffect(lambda)
+    }
+    return this
+}
+
+/**
+ * Convenience extension to extend an existing signal handler in a Transformer.
+ */
+inline fun <reified T : Transmission.Signal> Transformer.extendSignalHandler(
+    noinline lambda: suspend CommunicationScope.(signal: T) -> Unit
+): Transformer {
+    updateHandlers {
+        extendSignal(lambda)
+    }
+    return this
+}
+
+/**
+ * Convenience extension to override an existing signal handler in a Transformer.
+ */
+inline fun <reified T : Transmission.Signal> Transformer.overrideSignalHandler(
+    noinline lambda: suspend CommunicationScope.(signal: T) -> Unit
+): Transformer {
+    updateHandlers {
+        overrideSignal(lambda)
+    }
+    return this
+}


### PR DESCRIPTION
# Added Extension Functions to Transformer API

This MR introduces extension functions for the Transformer class that enable incremental modification of handlers, computations, and executions. These functions provide a more flexible way to define and update handlers without clearing existing ones.

## Key Additions:

- addHandlers(): Add new signal and effect handlers incrementally
- updateHandlers(): Extend or override existing handlers
- addComputations(): Register computation functions incrementally
- addExecutions(): Register execution functions incrementally
- Convenience extensions for directly registering computations and executions
- Shorthand methods for extending/overriding effect and signal handlers

## Benefits:
These extensions make the Transformer API more flexible by allowing handlers to be defined in init blocks or separate functions, rather than requiring all handlers to be defined in a single scope. This improves code organization and maintainability, especially for complex transformers.
Example Use Case:

```kotlin
MyTransformer : Transformer() {
    init {
        // Add additional handlers separately
        addHandlers {
            onEffect<SomeEffect> { /* handle effect */ }
        }
        
        // Extend existing handlers
        updateHandlers {
            extendSignal<BaseSignal> { /* additional handling */ }
        }
    }
}
```