### PR TITLE
Oneshot payload

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 # Library versions
-transmission-core = "1.4.2"
-transmission-test = "1.4.2"
+transmission-core = "1.5.0"
+transmission-test = "1.5.0"
 
 # Kotlin and build tools
 agp = "8.2.2"

--- a/transmission/src/main/java/com/trendyol/transmission/effect/RouterEffectWithType.kt
+++ b/transmission/src/main/java/com/trendyol/transmission/effect/RouterEffectWithType.kt
@@ -1,0 +1,5 @@
+package com.trendyol.transmission.effect
+
+import com.trendyol.transmission.Transmission
+
+data class RouterEffectWithType<T: Any>(val payload: T): Transmission.Effect

--- a/transmission/src/main/java/com/trendyol/transmission/effect/RouterEffectWithType.kt
+++ b/transmission/src/main/java/com/trendyol/transmission/effect/RouterEffectWithType.kt
@@ -1,5 +1,7 @@
 package com.trendyol.transmission.effect
 
+import com.trendyol.transmission.InternalTransmissionApi
 import com.trendyol.transmission.Transmission
 
+@InternalTransmissionApi
 data class RouterEffectWithType<T: Any>(val payload: T): Transmission.Effect

--- a/transmission/src/main/java/com/trendyol/transmission/router/StreamExt.kt
+++ b/transmission/src/main/java/com/trendyol/transmission/router/StreamExt.kt
@@ -1,11 +1,15 @@
 package com.trendyol.transmission.router
 
 import com.trendyol.transmission.Transmission
+import com.trendyol.transmission.effect.RouterEffectWithType
+import com.trendyol.transmission.effect.WrappedEffect
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.filterIsInstance
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.stateIn
 
@@ -57,4 +61,8 @@ inline fun <reified T : Transmission.Data> Flow<T>.asState(
     sharingStarted: SharingStarted = SharingStarted.WhileSubscribed(),
 ): StateFlow<T> {
     return this.filterIsInstance<T>().stateIn(scope, sharingStarted, initialValue)
+}
+
+inline fun <reified D: Any> TransmissionRouter.oneShotPayloadStream(): Flow<D> {
+    return this.effectStream.filterIsInstance<RouterEffectWithType<D>>().map { it.payload }
 }

--- a/transmission/src/main/java/com/trendyol/transmission/router/StreamExt.kt
+++ b/transmission/src/main/java/com/trendyol/transmission/router/StreamExt.kt
@@ -1,5 +1,7 @@
 package com.trendyol.transmission.router
 
+import com.trendyol.transmission.ExperimentalTransmissionApi
+import com.trendyol.transmission.InternalTransmissionApi
 import com.trendyol.transmission.Transmission
 import com.trendyol.transmission.effect.RouterEffectWithType
 import com.trendyol.transmission.effect.WrappedEffect
@@ -63,6 +65,8 @@ inline fun <reified T : Transmission.Data> Flow<T>.asState(
     return this.filterIsInstance<T>().stateIn(scope, sharingStarted, initialValue)
 }
 
+@OptIn(InternalTransmissionApi::class)
+@ExperimentalTransmissionApi
 inline fun <reified D: Any> TransmissionRouter.oneShotPayloadStream(): Flow<D> {
     return this.effectStream.filterIsInstance<RouterEffectWithType<D>>().map { it.payload }
 }

--- a/transmission/src/main/java/com/trendyol/transmission/transformer/CommunicationScopeImpl.kt
+++ b/transmission/src/main/java/com/trendyol/transmission/transformer/CommunicationScopeImpl.kt
@@ -2,6 +2,7 @@ package com.trendyol.transmission.transformer
 
 import com.trendyol.transmission.ExperimentalTransmissionApi
 import com.trendyol.transmission.Transmission
+import com.trendyol.transmission.effect.RouterEffectWithType
 import com.trendyol.transmission.effect.WrappedEffect
 import com.trendyol.transmission.transformer.handler.CommunicationScope
 import com.trendyol.transmission.transformer.request.Contract
@@ -18,6 +19,10 @@ internal class CommunicationScopeImpl(
 
     override suspend fun <D : Transmission.Data> send(data: D?) {
         data?.let { dataChannel.send(it) }
+    }
+
+    override suspend fun <D : Any> sendPayload(payload: D) {
+        effectChannel.send(WrappedEffect(RouterEffectWithType<D>(payload)))
     }
 
     override suspend fun <E : Transmission.Effect> send(

--- a/transmission/src/main/java/com/trendyol/transmission/transformer/Transformer.kt
+++ b/transmission/src/main/java/com/trendyol/transmission/transformer/Transformer.kt
@@ -3,6 +3,7 @@ package com.trendyol.transmission.transformer
 import com.trendyol.transmission.ExperimentalTransmissionApi
 import com.trendyol.transmission.Transmission
 import com.trendyol.transmission.effect.RouterEffect
+import com.trendyol.transmission.effect.RouterEffectWithType
 import com.trendyol.transmission.effect.WrappedEffect
 import com.trendyol.transmission.router.Capacity
 import com.trendyol.transmission.transformer.checkpoint.CheckpointTracker
@@ -117,6 +118,7 @@ open class Transformer(
                 launch {
                     incoming
                         .filterNot { it.effect is RouterEffect }
+                        .filterNot { it.effect is RouterEffectWithType<*> }
                         .filter { it.identity == null || it.identity == _identity }
                         .map { it.effect }
                         .collect {

--- a/transmission/src/main/java/com/trendyol/transmission/transformer/handler/CommunicationScope.kt
+++ b/transmission/src/main/java/com/trendyol/transmission/transformer/handler/CommunicationScope.kt
@@ -1,5 +1,6 @@
 package com.trendyol.transmission.transformer.handler
 
+import com.trendyol.transmission.ExperimentalTransmissionApi
 import com.trendyol.transmission.Transmission
 import com.trendyol.transmission.router.TransmissionRouter
 import com.trendyol.transmission.transformer.Transformer
@@ -25,6 +26,7 @@ interface CommunicationScope : QueryHandler, CheckpointHandler {
      * These can be observed via one-shot payload observers
      * @param payload Arbitrary data to send
      */
+    @ExperimentalTransmissionApi
     suspend fun <D: Any> sendPayload(payload: D)
 
     /**

--- a/transmission/src/main/java/com/trendyol/transmission/transformer/handler/CommunicationScope.kt
+++ b/transmission/src/main/java/com/trendyol/transmission/transformer/handler/CommunicationScope.kt
@@ -21,6 +21,13 @@ interface CommunicationScope : QueryHandler, CheckpointHandler {
     suspend fun <E : Transmission.Effect> publish(effect: E)
 
     /**
+     * Sends arbitrary payload to [TransmissionRouter] via [Transmission.Effect] internally.
+     * These can be observed via one-shot payload observers
+     * @param payload Arbitrary data to send
+     */
+    suspend fun <D: Any> sendPayload(payload: D)
+
+    /**
      * Sends [Transmission.Effect] to a specific [Transformer]
      * @param effect of type [Transmission.Effect]
      * @param to Target [Transformer] identity Contract


### PR DESCRIPTION
This MR introduces `sendPayload` function and experimental `oneShotPayloadStream` extension to observe these one shot events.

## Context

Transmission Library sends effects to the Router. There is also `RouterEffect` which directly sends the payload to the router. 

In addition to this, we added experimental `sendPayload` function. This can be used to emulate the behavior of singleLiveEvent. Transformers can send these payloads, and in ViewModel, we can directly observe these one-time events. 

```kotlin
// on CommunicationScope
/**
 * Sends arbitrary payload to [TransmissionRouter] via [Transmission.Effect] internally.
 * These can be observed via one-shot payload observers
 * @param payload Arbitrary data to send
 */
@ExperimentalTransmissionApi
suspend fun <D: Any> sendPayload(payload: D)

// on StreamExt

@OptIn(InternalTransmissionApi::class)
@ExperimentalTransmissionApi
inline fun <reified D: Any> TransmissionRouter.oneShotPayloadStream(): Flow<D> {
    return this.effectStream.filterIsInstance<RouterEffectWithType<D>>().map { it.payload }
}

```

You can define oneShotPayloadStreams like so

```kotlin
val oneShot: Flow<InputUiState> = router.oneShotPayloadStream<InputUiState>()
```